### PR TITLE
Adding mixlib-cli mixin for exposing --accept-licence command line flag

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,6 +16,7 @@ GEM
     diff-lcs (1.3)
     equatable (0.5.0)
     method_source (0.9.2)
+    mixlib-cli (1.7.0)
     necromancer (0.4.0)
     pastel (0.7.2)
       equatable (~> 0.5.0)
@@ -65,6 +66,7 @@ PLATFORMS
 DEPENDENCIES
   bundler (~> 1.17)
   license-acceptance!
+  mixlib-cli (~> 1.7)
   pry (~> 0.12)
   pry-byebug (~> 3.6)
   pry-stack_explorer (~> 0.4)
@@ -72,4 +74,4 @@ DEPENDENCIES
   rspec (~> 3.0)
 
 BUNDLED WITH
-   1.17.2
+   1.17.3

--- a/lib/license_acceptance/cli_flags/mixlib_cli.rb
+++ b/lib/license_acceptance/cli_flags/mixlib_cli.rb
@@ -1,0 +1,22 @@
+begin
+  require 'mixlib/cli'
+rescue => exception
+  raise "Must have mixlib-cli gem installed to use this mixin"
+end
+
+module LicenseAcceptance
+  module CLIFlags
+
+    module MixlibCLI
+
+      def self.included(klass)
+        klass.option :accept_license,
+          long: "--accept-license",
+          description: "Accept the license for this product and any contained products",
+          boolean: true
+      end
+
+    end
+
+  end
+end

--- a/licence-acceptance.gemspec
+++ b/licence-acceptance.gemspec
@@ -41,4 +41,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "pry", "~> 0.12"
   spec.add_development_dependency "pry-byebug", "~> 3.6"
   spec.add_development_dependency "pry-stack_explorer", "~> 0.4"
+  spec.add_development_dependency "mixlib-cli", "~> 1.7"
 end

--- a/spec/license_acceptance/cli_flags/mixlib_cli_spec.rb
+++ b/spec/license_acceptance/cli_flags/mixlib_cli_spec.rb
@@ -1,0 +1,14 @@
+require "spec_helper"
+require "license_acceptance/cli_flags/mixlib_cli"
+
+class TestKlass
+  include Mixlib::CLI
+  include LicenseAcceptance::CLIFlags::MixlibCLI
+end
+
+RSpec.describe LicenseAcceptance::CLIFlags::MixlibCLI do
+  let(:klass) { TestKlass.new }
+  it "adds the correct command line flag" do
+    expect(klass.options).to include(:accept_license)
+  end
+end


### PR DESCRIPTION
Expose a simple API (including a mixin) so consumers of this library
can easily add `--accept-license` help text to their application.

Signed-off-by: tyler-ball <tball@chef.io>