### PR TITLE
Add explicit begin for Timeout block to support ruby < 2.5

### DIFF
--- a/components/ruby/lib/license_acceptance/prompt_acceptance.rb
+++ b/components/ruby/lib/license_acceptance/prompt_acceptance.rb
@@ -68,13 +68,15 @@ module LicenseAcceptance
       prompt = TTY::Prompt.new(track_history: false, active_color: :bold, interrupt: :exit, output: output)
 
       answer = "no"
-      Timeout::timeout(60, PromptTimeout) do
-        answer = prompt.ask(">") do |q|
-          q.modify :down, :trim
-          q.required true
-          q.messages[:required?] = "You must enter 'yes' or 'no'"
-          q.validate /^\s*(yes|no)\s*$/i
-          q.messages[:valid?] = "You must enter 'yes' or 'no'"
+      begin
+        Timeout::timeout(60, PromptTimeout) do
+          answer = prompt.ask(">") do |q|
+            q.modify :down, :trim
+            q.required true
+            q.messages[:required?] = "You must enter 'yes' or 'no'"
+            q.validate /^\s*(yes|no)\s*$/i
+            q.messages[:valid?] = "You must enter 'yes' or 'no'"
+          end
         end
       rescue PromptTimeout
         prompt.unsubscribe(prompt.reader)


### PR DESCRIPTION
Signed-off-by: Clinton Wolfe <clintoncwolfe@gmail.com>

Fixes a syntax error that occurs on Ruby 2.4 and 2.3:
```
bundler: failed to load command: inspec (/Users/cwolfe/.rbenv/versions/2.4.5/lib/ruby/gems/2.4.0/bin/inspec)
SyntaxError: /Users/cwolfe/sandbox/inspec/license-acceptance/components/ruby/lib/license_acceptance/prompt_acceptance.rb:79: syntax error, unexpected keyword_rescue, expecting keyword_end
      rescue PromptTimeout
            ^
```

## Description

Added an explicit `begin`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
