### PR TITLE
tty-platform library is interfering with chef-client

### DIFF
--- a/components/ruby/Gemfile.lock
+++ b/components/ruby/Gemfile.lock
@@ -1,11 +1,10 @@
 PATH
   remote: .
   specs:
-    license-acceptance (0.2.3)
+    license-acceptance (0.2.5)
       pastel (~> 0.7)
       tomlrb (~> 1.2)
       tty-box (~> 0.3)
-      tty-platform (~> 0.2)
       tty-prompt (~> 0.18)
 
 GEM
@@ -62,7 +61,6 @@ GEM
       tty-cursor (~> 0.6.0)
     tty-color (0.4.3)
     tty-cursor (0.6.1)
-    tty-platform (0.2.0)
     tty-prompt (0.18.1)
       necromancer (~> 0.4.0)
       pastel (~> 0.7.0)

--- a/components/ruby/lib/license_acceptance/config.rb
+++ b/components/ruby/lib/license_acceptance/config.rb
@@ -1,5 +1,4 @@
 require 'logger'
-require 'tty-platform'
 
 module LicenseAcceptance
   class Config
@@ -16,16 +15,12 @@ module LicenseAcceptance
 
     private
 
-    def platform
-      @platform ||= TTY::Platform.new
-    end
-
     def is_root?
       Process.uid == 0
     end
 
     def default_license_locations
-      if platform.windows?
+      if windows?
         l = [ File.join(ENV["HOMEDRIVE"], "chef/accepted_licenses/") ]
         unless is_root?
           # Look through a list of possible user locations and pick the first one that exists
@@ -53,6 +48,10 @@ module LicenseAcceptance
 
     def default_persist_location
       license_locations[-1]
+    end
+
+    def windows?
+      !!(RUBY_PLATFORM =~ /(cygwin|mswin|mingw|bccwin|wince|emx)/i)
     end
 
   end

--- a/components/ruby/license-acceptance.gemspec
+++ b/components/ruby/license-acceptance.gemspec
@@ -23,7 +23,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'pastel', "~> 0.7"
   spec.add_dependency 'tomlrb', "~> 1.2"
   spec.add_dependency 'tty-box', "~> 0.3"
-  spec.add_dependency 'tty-platform', "~> 0.2"
   spec.add_dependency 'tty-prompt', "~> 0.18"
 
   spec.add_development_dependency "rake", "~> 10.0"

--- a/components/ruby/spec/license_acceptance/config_spec.rb
+++ b/components/ruby/spec/license_acceptance/config_spec.rb
@@ -6,7 +6,6 @@ require "license_acceptance/product_relationship"
 RSpec.describe LicenseAcceptance::Config do
   let(:opts) { {} }
   let(:config) { LicenseAcceptance::Config.new(opts) }
-  let(:platform) { instance_double(TTY::Platform) }
 
   it "loads correctly with default values" do
     config
@@ -31,13 +30,12 @@ RSpec.describe LicenseAcceptance::Config do
 
   describe "#default_license_locations and #default_persist_location" do
     before do
-      expect(TTY::Platform).to receive(:new).and_return(platform)
       expect(Process).to receive(:uid).and_return(uid)
     end
 
     describe "when platform is Windows" do
       before do
-        expect(platform).to receive(:windows?).and_return(true)
+        stub_const("RUBY_PLATFORM", "mingw")
       end
 
       describe "when user is Administrator" do
@@ -81,7 +79,7 @@ RSpec.describe LicenseAcceptance::Config do
 
     describe "when platform is non-Windows" do
       before do
-        expect(platform).to receive(:windows?).and_return(false)
+        stub_const("RUBY_PLATFORM", "darwin")
       end
 
       describe "when user is root" do


### PR DESCRIPTION
## Description
Somehow it is overriding the 'windows?' helper method in the chef
codebase. Not sure how, but we only need 1 method so just importing
that.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
