### PR TITLE
Gem and Habitat packages only need unstable and stable releases

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -1,5 +1,8 @@
 # Documentation available at https://expeditor.chef.io/docs/getting-started/
 
+project:
+  alias: license-acceptance
+
 # https://expeditor.chef.io/docs/integrations/slack/
 slack:
   notify_channel: _license_acceptance
@@ -22,7 +25,8 @@ github:
     - "Expeditor: Bump Version Major"
 
 pipelines:
-  - verify
+  - verify:
+      public: true
   - habitat/build
 
 # These actions are taken, in order they are specified, anytime a Pull Request is merged.
@@ -50,10 +54,7 @@ merge_actions:
   #https://github.com/golang/go/wiki/Modules#releasing-modules-all-versions
 
 promote:
-  channels:
-    - unstable
-    - current
-    - stable
   actions:
+    - built_in:rollover_changelog
     - built_in:promote_habitat_packages
     - built_in:publish_rubygems

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 - tty-platform library is interfering with chef-client [#22](https://github.com/chef/license-acceptance/pull/22) ([tyler-ball](https://github.com/tyler-ball))
 <!-- latest_release -->
 
+<!-- release_rollup since=0.2.5-->
+
 ## [v0.2.5](https://github.com/chef/license-acceptance/tree/v0.2.5) (2019-04-10)
 
 #### Merged Pull Requests
@@ -34,3 +36,9 @@
 
 #### Merged Pull Requests
 - Adding initial expeditor configuration [#16](https://github.com/chef/license-acceptance/pull/16) ([tyler-ball](https://github.com/tyler-ball))
+
+<!-- release_rollup -->
+
+<!-- latest_stable_release -->
+
+<!-- latest_stable_release -->


### PR DESCRIPTION
This is the default promote strategy for non-Omnibus packages.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
