### PR TITLE
Add silent license acceptance option

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,13 +99,15 @@ to keep a consistent experience among all Chef Software products.
 
 See the [Ruby README](./components/ruby/README.md) for developer notes on consuming this library.
 
-Users accept the license by passing one of the following options. The `no-persist` options means the license marker file
-will not attempt to be persisted to the filesystem:
+Users accept the license by passing one of the following options. The `silent` options suppress any output on STDOUT.
+The `no-persist` options means the license marker file will not attempt to be persisted to the filesystem.
 
 * `--chef-license accept`
 * `--chef-license accept-no-persist`
+* `--chef-license accept-silent`
 * `ENV[CHEF_LICENSE]=accept`
 * `ENV[CHEF_LICENSE]=accept-no-persist`
+* `ENV[CHEF_LICENSE]=accept-silent`
 
 ### License File Persistence
 

--- a/components/ruby/Gemfile.lock
+++ b/components/ruby/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    license-acceptance (0.2.5)
+    license-acceptance (0.2.7)
       pastel (~> 0.7)
       tomlrb (~> 1.2)
       tty-box (~> 0.3)

--- a/components/ruby/lib/license_acceptance/acceptor.rb
+++ b/components/ruby/lib/license_acceptance/acceptor.rb
@@ -58,7 +58,9 @@ module LicenseAcceptance
         if config.persist
           errs = file_acceptance.persist(product_relationship, missing_licenses)
           if errs.empty?
-            output_num_persisted(missing_licenses.size)
+            unless env_acceptance.silent?(ENV) || arg_acceptance.silent?(ARGV)
+              output_num_persisted(missing_licenses.size)
+            end
           else
             output_persist_failed(errs)
           end

--- a/components/ruby/lib/license_acceptance/arg_acceptance.rb
+++ b/components/ruby/lib/license_acceptance/arg_acceptance.rb
@@ -1,50 +1,32 @@
 module LicenseAcceptance
   class ArgAcceptance
 
-    # TODO: DRY this up
-
     def check(argv)
       return true if silent?(argv)
-      if argv.include?("--chef-license=accept")
-        return true
-      end
-      i = argv.index("--chef-license")
-      unless i.nil?
-        val = argv[i+1]
-        if val != nil && val.downcase == "accept"
-          return true
-        end
-      end
-      return false
+      look_for_value(argv, "accept")
     end
 
     def silent?(argv)
-      if argv.include?("--chef-license=accept-silent")
-        return true
-      end
-      i = argv.index("--chef-license")
-      unless i.nil?
-        val = argv[i+1]
-        if val != nil && val.downcase == "accept-silent"
-          return true
-        end
-      end
-      return false
+      look_for_value(argv, "accept-silent")
     end
 
     def check_no_persist(argv)
-      if argv.include?("--chef-license=accept-no-persist")
+      look_for_value(argv, "accept-no-persist")
+    end
+
+    private
+    def look_for_value(argv, sought)
+      if argv.include?("--chef-license=#{sought}")
         return true
       end
       i = argv.index("--chef-license")
       unless i.nil?
         val = argv[i+1]
-        if val != nil && val.downcase == "accept-no-persist"
+        if val != nil && val.downcase == sought
           return true
         end
       end
       return false
     end
-
   end
 end

--- a/components/ruby/lib/license_acceptance/arg_acceptance.rb
+++ b/components/ruby/lib/license_acceptance/arg_acceptance.rb
@@ -1,8 +1,7 @@
 module LicenseAcceptance
   class ArgAcceptance
 
-    def check(argv)
-      return true if silent?(argv)
+    def accepted?(argv)
       look_for_value(argv, "accept")
     end
 
@@ -10,11 +9,12 @@ module LicenseAcceptance
       look_for_value(argv, "accept-silent")
     end
 
-    def check_no_persist(argv)
+    def no_persist?(argv)
       look_for_value(argv, "accept-no-persist")
     end
 
     private
+
     def look_for_value(argv, sought)
       if argv.include?("--chef-license=#{sought}")
         return true

--- a/components/ruby/lib/license_acceptance/arg_acceptance.rb
+++ b/components/ruby/lib/license_acceptance/arg_acceptance.rb
@@ -1,7 +1,10 @@
 module LicenseAcceptance
   class ArgAcceptance
 
+    # TODO: DRY this up
+
     def check(argv)
+      return true if silent?(argv)
       if argv.include?("--chef-license=accept")
         return true
       end
@@ -9,6 +12,20 @@ module LicenseAcceptance
       unless i.nil?
         val = argv[i+1]
         if val != nil && val.downcase == "accept"
+          return true
+        end
+      end
+      return false
+    end
+
+    def silent?(argv)
+      if argv.include?("--chef-license=accept-silent")
+        return true
+      end
+      i = argv.index("--chef-license")
+      unless i.nil?
+        val = argv[i+1]
+        if val != nil && val.downcase == "accept-silent"
           return true
         end
       end

--- a/components/ruby/lib/license_acceptance/cli_flags/mixlib_cli.rb
+++ b/components/ruby/lib/license_acceptance/cli_flags/mixlib_cli.rb
@@ -12,7 +12,7 @@ module LicenseAcceptance
       def self.included(klass)
         klass.option :chef_license,
           long: "--chef-license ACCEPTANCE",
-          description: "Accept the license for this product and any contained products ('accept' or 'accept-no-persist')",
+          description: "Accept the license for this product and any contained products ('accept', 'accept-no-persist', or 'accept-silent')",
           required: false
       end
 

--- a/components/ruby/lib/license_acceptance/cli_flags/thor.rb
+++ b/components/ruby/lib/license_acceptance/cli_flags/thor.rb
@@ -12,7 +12,7 @@ module LicenseAcceptance
       def self.included(klass)
         klass.class_option :chef_license,
           type: :string,
-          desc: 'Accept the license for this product and any contained products: accept, accept-no-persist'
+          desc: 'Accept the license for this product and any contained products: accept, accept-no-persist, accept-silent'
       end
 
     end

--- a/components/ruby/lib/license_acceptance/env_acceptance.rb
+++ b/components/ruby/lib/license_acceptance/env_acceptance.rb
@@ -1,8 +1,7 @@
 module LicenseAcceptance
   class EnvAcceptance
 
-    def check(env)
-      return true if silent?(env)
+    def accepted?(env)
       look_for_value(env, "accept")
     end
 
@@ -10,11 +9,12 @@ module LicenseAcceptance
       look_for_value(env, "accept-silent")
     end
 
-    def check_no_persist(env)
+    def no_persist?(env)
       look_for_value(env, "accept-no-persist")
     end
 
     private
+
     def look_for_value(env, sought)
       if env['CHEF_LICENSE'] && env['CHEF_LICENSE'].downcase == sought
         return true

--- a/components/ruby/lib/license_acceptance/env_acceptance.rb
+++ b/components/ruby/lib/license_acceptance/env_acceptance.rb
@@ -2,14 +2,21 @@ module LicenseAcceptance
   class EnvAcceptance
 
     def check(env)
-      if env['CHEF_LICENSE'] && env['CHEF_LICENSE'].downcase == 'accept'
-        return true
-      end
-      return false
+      return true if silent?(env)
+      look_for_value(env, "accept")
+    end
+
+    def silent?(env)
+      look_for_value(env, "accept-silent")
     end
 
     def check_no_persist(env)
-      if env['CHEF_LICENSE'] && env['CHEF_LICENSE'].downcase == 'accept-no-persist'
+      look_for_value(env, "accept-no-persist")
+    end
+
+    private
+    def look_for_value(env, sought)
+      if env['CHEF_LICENSE'] && env['CHEF_LICENSE'].downcase == sought
         return true
       end
       return false

--- a/components/ruby/lib/license_acceptance/file_acceptance.rb
+++ b/components/ruby/lib/license_acceptance/file_acceptance.rb
@@ -18,7 +18,7 @@ module LicenseAcceptance
 
     # For all the given products in the product set, search all possible locations for the
     # license acceptance files.
-    def check(product_relationship)
+    def accepted?(product_relationship)
       searching = [product_relationship.parent] + product_relationship.children
       missing_licenses = searching.clone
       logger.debug("Searching for the following licenses: #{missing_licenses.map(&:name)}")

--- a/components/ruby/spec/license_acceptance/acceptor_spec.rb
+++ b/components/ruby/spec/license_acceptance/acceptor_spec.rb
@@ -77,6 +77,8 @@ RSpec.describe LicenseAcceptance::Acceptor do
         expect(reader).to receive(:lookup).with(product, version).and_return(relationship)
         expect(file_acc).to receive(:check).with(relationship).and_return(missing)
         expect(env_acc).to receive(:check).with(ENV).and_return(true)
+        expect(env_acc).to receive(:silent?).with(ENV).and_return(false)
+        expect(arg_acc).to receive(:silent?).with(ARGV).and_return(false)
         expect(file_acc).to receive(:persist).with(relationship, missing).and_return([])
         expect(acc.check_and_persist(product, version)).to eq(true)
         expect(output.string).to match(/1 product license accepted./)
@@ -94,6 +96,23 @@ RSpec.describe LicenseAcceptance::Acceptor do
           expect(env_acc).to receive(:check).with(ENV).and_return(true)
           expect(acc.check_and_persist(product, version)).to eq(true)
           expect(output.string).to_not match(/accepted./)
+        end
+      end
+
+      describe "when the silent option is used" do
+        let(:opts) { { output: output } }
+
+        it "returns true and silently persists the file" do
+          expect(env_acc).to receive(:check_no_persist).and_return(false)
+          expect(arg_acc).to receive(:check_no_persist).and_return(false)
+          expect(reader).to receive(:read)
+          expect(reader).to receive(:lookup).with(product, version).and_return(relationship)
+          expect(file_acc).to receive(:check).with(relationship).and_return(missing)
+          expect(env_acc).to receive(:check).with(ENV).and_return(true)
+          expect(env_acc).to receive(:silent?).with(ENV).and_return(true)
+          expect(file_acc).to receive(:persist).with(relationship, missing).and_return([])
+          expect(acc.check_and_persist(product, version)).to eq(true)
+          expect(output.string).to be_empty
         end
       end
 
@@ -121,10 +140,32 @@ RSpec.describe LicenseAcceptance::Acceptor do
         expect(file_acc).to receive(:check).with(relationship).and_return(missing)
         expect(env_acc).to receive(:check).and_return(false)
         expect(arg_acc).to receive(:check).with(ARGV).and_return(true)
+        expect(env_acc).to receive(:silent?).with(ENV).and_return(false)
+        expect(arg_acc).to receive(:silent?).with(ARGV).and_return(false)
         expect(file_acc).to receive(:persist).with(relationship, missing).and_return([])
         expect(acc.check_and_persist(product, version)).to eq(true)
         expect(output.string).to match(/1 product license accepted./)
       end
+
+      describe "when the silent option is used" do
+        let(:opts) { { output: output } }
+
+        it "returns true and silently persists the file" do
+          expect(env_acc).to receive(:check_no_persist).and_return(false)
+          expect(arg_acc).to receive(:check_no_persist).and_return(false)
+          expect(reader).to receive(:read)
+          expect(reader).to receive(:lookup).with(product, version).and_return(relationship)
+          expect(file_acc).to receive(:check).with(relationship).and_return(missing)
+          expect(env_acc).to receive(:check).and_return(false)
+          expect(arg_acc).to receive(:check).with(ARGV).and_return(true)
+          expect(env_acc).to receive(:silent?).with(ENV).and_return(false)
+          expect(arg_acc).to receive(:silent?).with(ARGV).and_return(true)
+          expect(file_acc).to receive(:persist).with(relationship, missing).and_return([])
+          expect(acc.check_and_persist(product, version)).to eq(true)
+          expect(output.string).to be_empty
+        end
+      end
+
 
       describe "when persist is set to false" do
         let(:opts) { { output: output, persist: false } }

--- a/components/ruby/spec/license_acceptance/acceptor_spec.rb
+++ b/components/ruby/spec/license_acceptance/acceptor_spec.rb
@@ -45,38 +45,38 @@ RSpec.describe LicenseAcceptance::Acceptor do
 
     describe "when check-no-persist environment variable is set" do
       it "returns true" do
-        expect(env_acc).to receive(:check_no_persist).and_return(true)
+        expect(env_acc).to receive(:no_persist?).and_return(true)
         expect(acc.check_and_persist(product, version)).to eq(true)
       end
     end
 
     describe "when check-no-persist command line argument is set" do
       it "returns true" do
-        expect(env_acc).to receive(:check_no_persist).and_return(false)
-        expect(arg_acc).to receive(:check_no_persist).and_return(true)
+        expect(env_acc).to receive(:no_persist?).and_return(false)
+        expect(arg_acc).to receive(:no_persist?).and_return(true)
         expect(acc.check_and_persist(product, version)).to eq(true)
       end
     end
 
     describe "when there are no missing licenses" do
       it "returns true" do
-        expect(env_acc).to receive(:check_no_persist).and_return(false)
-        expect(arg_acc).to receive(:check_no_persist).and_return(false)
+        expect(env_acc).to receive(:no_persist?).and_return(false)
+        expect(arg_acc).to receive(:no_persist?).and_return(false)
         expect(reader).to receive(:read)
         expect(reader).to receive(:lookup).with(product, version).and_return(relationship)
-        expect(file_acc).to receive(:check).with(relationship).and_return([])
+        expect(file_acc).to receive(:accepted?).with(relationship).and_return([])
         expect(acc.check_and_persist(product, version)).to eq(true)
       end
     end
 
     describe "when the user accepts as an environment variable" do
       it "returns true" do
-        expect(env_acc).to receive(:check_no_persist).and_return(false)
-        expect(arg_acc).to receive(:check_no_persist).and_return(false)
+        expect(env_acc).to receive(:no_persist?).and_return(false)
+        expect(arg_acc).to receive(:no_persist?).and_return(false)
         expect(reader).to receive(:read)
         expect(reader).to receive(:lookup).with(product, version).and_return(relationship)
-        expect(file_acc).to receive(:check).with(relationship).and_return(missing)
-        expect(env_acc).to receive(:check).with(ENV).and_return(true)
+        expect(file_acc).to receive(:accepted?).with(relationship).and_return(missing)
+        expect(env_acc).to receive(:accepted?).with(ENV).and_return(true)
         expect(env_acc).to receive(:silent?).with(ENV).and_return(false)
         expect(arg_acc).to receive(:silent?).with(ARGV).and_return(false)
         expect(file_acc).to receive(:persist).with(relationship, missing).and_return([])
@@ -88,12 +88,12 @@ RSpec.describe LicenseAcceptance::Acceptor do
         let(:opts) { { output: output, persist: false } }
 
         it "returns true" do
-          expect(env_acc).to receive(:check_no_persist).and_return(false)
-          expect(arg_acc).to receive(:check_no_persist).and_return(false)
+          expect(env_acc).to receive(:no_persist?).and_return(false)
+          expect(arg_acc).to receive(:no_persist?).and_return(false)
           expect(reader).to receive(:read)
           expect(reader).to receive(:lookup).with(product, version).and_return(relationship)
-          expect(file_acc).to receive(:check).with(relationship).and_return(missing)
-          expect(env_acc).to receive(:check).with(ENV).and_return(true)
+          expect(file_acc).to receive(:accepted?).with(relationship).and_return(missing)
+          expect(env_acc).to receive(:accepted?).with(ENV).and_return(true)
           expect(acc.check_and_persist(product, version)).to eq(true)
           expect(output.string).to_not match(/accepted./)
         end
@@ -103,13 +103,14 @@ RSpec.describe LicenseAcceptance::Acceptor do
         let(:opts) { { output: output } }
 
         it "returns true and silently persists the file" do
-          expect(env_acc).to receive(:check_no_persist).and_return(false)
-          expect(arg_acc).to receive(:check_no_persist).and_return(false)
+          expect(env_acc).to receive(:no_persist?).and_return(false)
+          expect(arg_acc).to receive(:no_persist?).and_return(false)
           expect(reader).to receive(:read)
           expect(reader).to receive(:lookup).with(product, version).and_return(relationship)
-          expect(file_acc).to receive(:check).with(relationship).and_return(missing)
-          expect(env_acc).to receive(:check).with(ENV).and_return(true)
-          expect(env_acc).to receive(:silent?).with(ENV).and_return(true)
+          expect(file_acc).to receive(:accepted?).with(relationship).and_return(missing)
+          expect(env_acc).to receive(:accepted?).with(ENV).and_return(false)
+          expect(arg_acc).to receive(:accepted?).with(ARGV).and_return(false)
+          expect(env_acc).to receive(:silent?).with(ENV).twice.and_return(true)
           expect(file_acc).to receive(:persist).with(relationship, missing).and_return([])
           expect(acc.check_and_persist(product, version)).to eq(true)
           expect(output.string).to be_empty
@@ -118,12 +119,12 @@ RSpec.describe LicenseAcceptance::Acceptor do
 
       describe "when file persistance fails" do
         it "returns true" do
-          expect(env_acc).to receive(:check_no_persist).and_return(false)
-          expect(arg_acc).to receive(:check_no_persist).and_return(false)
+          expect(env_acc).to receive(:no_persist?).and_return(false)
+          expect(arg_acc).to receive(:no_persist?).and_return(false)
           expect(reader).to receive(:read)
           expect(reader).to receive(:lookup).with(product, version).and_return(relationship)
-          expect(file_acc).to receive(:check).with(relationship).and_return(missing)
-          expect(env_acc).to receive(:check).with(ENV).and_return(true)
+          expect(file_acc).to receive(:accepted?).with(relationship).and_return(missing)
+          expect(env_acc).to receive(:accepted?).with(ENV).and_return(true)
           expect(file_acc).to receive(:persist).with(relationship, missing).and_return([StandardError.new("foo")])
           expect(acc.check_and_persist(product, version)).to eq(true)
           expect(output.string).to match(/Could not persist acceptance:/)
@@ -133,13 +134,13 @@ RSpec.describe LicenseAcceptance::Acceptor do
 
     describe "when the user accepts as an arg" do
       it "returns true" do
-        expect(env_acc).to receive(:check_no_persist).and_return(false)
-        expect(arg_acc).to receive(:check_no_persist).and_return(false)
+        expect(env_acc).to receive(:no_persist?).and_return(false)
+        expect(arg_acc).to receive(:no_persist?).and_return(false)
         expect(reader).to receive(:read)
         expect(reader).to receive(:lookup).with(product, version).and_return(relationship)
-        expect(file_acc).to receive(:check).with(relationship).and_return(missing)
-        expect(env_acc).to receive(:check).and_return(false)
-        expect(arg_acc).to receive(:check).with(ARGV).and_return(true)
+        expect(file_acc).to receive(:accepted?).with(relationship).and_return(missing)
+        expect(env_acc).to receive(:accepted?).and_return(false)
+        expect(arg_acc).to receive(:accepted?).with(ARGV).and_return(true)
         expect(env_acc).to receive(:silent?).with(ENV).and_return(false)
         expect(arg_acc).to receive(:silent?).with(ARGV).and_return(false)
         expect(file_acc).to receive(:persist).with(relationship, missing).and_return([])
@@ -151,15 +152,15 @@ RSpec.describe LicenseAcceptance::Acceptor do
         let(:opts) { { output: output } }
 
         it "returns true and silently persists the file" do
-          expect(env_acc).to receive(:check_no_persist).and_return(false)
-          expect(arg_acc).to receive(:check_no_persist).and_return(false)
+          expect(env_acc).to receive(:no_persist?).and_return(false)
+          expect(arg_acc).to receive(:no_persist?).and_return(false)
           expect(reader).to receive(:read)
           expect(reader).to receive(:lookup).with(product, version).and_return(relationship)
-          expect(file_acc).to receive(:check).with(relationship).and_return(missing)
-          expect(env_acc).to receive(:check).and_return(false)
-          expect(arg_acc).to receive(:check).with(ARGV).and_return(true)
-          expect(env_acc).to receive(:silent?).with(ENV).and_return(false)
-          expect(arg_acc).to receive(:silent?).with(ARGV).and_return(true)
+          expect(file_acc).to receive(:accepted?).with(relationship).and_return(missing)
+          expect(env_acc).to receive(:accepted?).and_return(false)
+          expect(arg_acc).to receive(:accepted?).with(ARGV).and_return(false)
+          expect(env_acc).to receive(:silent?).with(ENV).twice.and_return(false)
+          expect(arg_acc).to receive(:silent?).with(ARGV).twice.and_return(true)
           expect(file_acc).to receive(:persist).with(relationship, missing).and_return([])
           expect(acc.check_and_persist(product, version)).to eq(true)
           expect(output.string).to be_empty
@@ -171,13 +172,13 @@ RSpec.describe LicenseAcceptance::Acceptor do
         let(:opts) { { output: output, persist: false } }
 
         it "returns true" do
-          expect(env_acc).to receive(:check_no_persist).and_return(false)
-          expect(arg_acc).to receive(:check_no_persist).and_return(false)
+          expect(env_acc).to receive(:no_persist?).and_return(false)
+          expect(arg_acc).to receive(:no_persist?).and_return(false)
           expect(reader).to receive(:read)
           expect(reader).to receive(:lookup).with(product, version).and_return(relationship)
-          expect(file_acc).to receive(:check).with(relationship).and_return(missing)
-          expect(env_acc).to receive(:check).and_return(false)
-          expect(arg_acc).to receive(:check).with(ARGV).and_return(true)
+          expect(file_acc).to receive(:accepted?).with(relationship).and_return(missing)
+          expect(env_acc).to receive(:accepted?).and_return(false)
+          expect(arg_acc).to receive(:accepted?).with(ARGV).and_return(true)
           expect(acc.check_and_persist(product, version)).to eq(true)
           expect(output.string).to_not match(/accepted./)
         end
@@ -185,13 +186,13 @@ RSpec.describe LicenseAcceptance::Acceptor do
 
       describe "when file persistance fails" do
         it "returns true" do
-          expect(env_acc).to receive(:check_no_persist).and_return(false)
-          expect(arg_acc).to receive(:check_no_persist).and_return(false)
+          expect(env_acc).to receive(:no_persist?).and_return(false)
+          expect(arg_acc).to receive(:no_persist?).and_return(false)
           expect(reader).to receive(:read)
           expect(reader).to receive(:lookup).with(product, version).and_return(relationship)
-          expect(file_acc).to receive(:check).with(relationship).and_return(missing)
-          expect(env_acc).to receive(:check).and_return(false)
-          expect(arg_acc).to receive(:check).with(ARGV).and_return(true)
+          expect(file_acc).to receive(:accepted?).with(relationship).and_return(missing)
+          expect(env_acc).to receive(:accepted?).and_return(false)
+          expect(arg_acc).to receive(:accepted?).with(ARGV).and_return(true)
           expect(file_acc).to receive(:persist).with(relationship, missing).and_return([StandardError.new("bar")])
           expect(acc.check_and_persist(product, version)).to eq(true)
           expect(output.string).to match(/Could not persist acceptance:/)
@@ -202,13 +203,15 @@ RSpec.describe LicenseAcceptance::Acceptor do
     describe "when the prompt is not a tty" do
       let(:opts) { { output: File.open(File::NULL, "w") } }
       it "raises a LicenseNotAcceptedError error" do
-        expect(env_acc).to receive(:check_no_persist).and_return(false)
-        expect(arg_acc).to receive(:check_no_persist).and_return(false)
+        expect(env_acc).to receive(:no_persist?).and_return(false)
+        expect(arg_acc).to receive(:no_persist?).and_return(false)
         expect(reader).to receive(:read)
         expect(reader).to receive(:lookup).with(product, version).and_return(relationship)
-        expect(file_acc).to receive(:check).with(relationship).and_return(missing)
-        expect(env_acc).to receive(:check).and_return(false)
-        expect(arg_acc).to receive(:check).and_return(false)
+        expect(file_acc).to receive(:accepted?).with(relationship).and_return(missing)
+        expect(env_acc).to receive(:accepted?).and_return(false)
+        expect(arg_acc).to receive(:accepted?).and_return(false)
+        expect(env_acc).to receive(:silent?).and_return(false)
+        expect(arg_acc).to receive(:silent?).and_return(false)
         expect(prompt_acc).to_not receive(:request)
         expect { acc.check_and_persist(product, version) }.to raise_error(LicenseAcceptance::LicenseNotAcceptedError)
       end
@@ -216,13 +219,15 @@ RSpec.describe LicenseAcceptance::Acceptor do
 
     describe "when the user accepts with the prompt" do
       it "returns true" do
-        expect(env_acc).to receive(:check_no_persist).and_return(false)
-        expect(arg_acc).to receive(:check_no_persist).and_return(false)
+        expect(env_acc).to receive(:no_persist?).and_return(false)
+        expect(arg_acc).to receive(:no_persist?).and_return(false)
         expect(reader).to receive(:read)
         expect(reader).to receive(:lookup).with(product, version).and_return(relationship)
-        expect(file_acc).to receive(:check).with(relationship).and_return(missing)
-        expect(env_acc).to receive(:check).and_return(false)
-        expect(arg_acc).to receive(:check).and_return(false)
+        expect(file_acc).to receive(:accepted?).with(relationship).and_return(missing)
+        expect(env_acc).to receive(:accepted?).and_return(false)
+        expect(arg_acc).to receive(:accepted?).and_return(false)
+        expect(env_acc).to receive(:silent?).and_return(false)
+        expect(arg_acc).to receive(:silent?).and_return(false)
         expect(prompt_acc).to receive(:request).with(missing).and_yield.and_return(true)
         expect(file_acc).to receive(:persist).with(relationship, missing)
         expect(acc.check_and_persist(product, version)).to eq(true)
@@ -232,13 +237,15 @@ RSpec.describe LicenseAcceptance::Acceptor do
         let(:opts) { { output: output, persist: false } }
 
         it "returns true" do
-          expect(env_acc).to receive(:check_no_persist).and_return(false)
-          expect(arg_acc).to receive(:check_no_persist).and_return(false)
+          expect(env_acc).to receive(:no_persist?).and_return(false)
+          expect(arg_acc).to receive(:no_persist?).and_return(false)
           expect(reader).to receive(:read)
           expect(reader).to receive(:lookup).with(product, version).and_return(relationship)
-          expect(file_acc).to receive(:check).with(relationship).and_return(missing)
-          expect(env_acc).to receive(:check).and_return(false)
-          expect(arg_acc).to receive(:check).and_return(false)
+          expect(file_acc).to receive(:accepted?).with(relationship).and_return(missing)
+          expect(env_acc).to receive(:accepted?).and_return(false)
+          expect(arg_acc).to receive(:accepted?).and_return(false)
+          expect(env_acc).to receive(:silent?).and_return(false)
+          expect(arg_acc).to receive(:silent?).and_return(false)
           expect(prompt_acc).to receive(:request).with(missing).and_yield.and_return(true)
           expect(acc.check_and_persist(product, version)).to eq(true)
         end
@@ -247,13 +254,15 @@ RSpec.describe LicenseAcceptance::Acceptor do
 
     describe "when the user declines with the prompt" do
       it "raises a LicenseNotAcceptedError error" do
-        expect(env_acc).to receive(:check_no_persist).and_return(false)
-        expect(arg_acc).to receive(:check_no_persist).and_return(false)
+        expect(env_acc).to receive(:no_persist?).and_return(false)
+        expect(arg_acc).to receive(:no_persist?).and_return(false)
         expect(reader).to receive(:read)
         expect(reader).to receive(:lookup).with(product, version).and_return(relationship)
-        expect(file_acc).to receive(:check).with(relationship).and_return(missing)
-        expect(env_acc).to receive(:check).and_return(false)
-        expect(arg_acc).to receive(:check).and_return(false)
+        expect(file_acc).to receive(:accepted?).with(relationship).and_return(missing)
+        expect(env_acc).to receive(:accepted?).and_return(false)
+        expect(arg_acc).to receive(:accepted?).and_return(false)
+        expect(env_acc).to receive(:silent?).and_return(false)
+        expect(arg_acc).to receive(:silent?).and_return(false)
         expect(prompt_acc).to receive(:request).with(missing).and_return(false)
         expect { acc.check_and_persist(product, version) }.to raise_error(LicenseAcceptance::LicenseNotAcceptedError)
       end

--- a/components/ruby/spec/license_acceptance/arg_acceptance_spec.rb
+++ b/components/ruby/spec/license_acceptance/arg_acceptance_spec.rb
@@ -4,17 +4,51 @@ require "license_acceptance/arg_acceptance"
 RSpec.describe LicenseAcceptance::ArgAcceptance do
   let(:acc) { LicenseAcceptance::ArgAcceptance.new }
 
-  describe "#check" do
-    it "returns true if the args contain the required flag with spaces" do
-      expect(acc.check(["--chef-license", "accept"])).to eq(true)
+  describe "with an accept option" do
+    describe "#check" do
+      it "returns true if the args contain the required flag with spaces" do
+        expect(acc.check(["--chef-license", "accept"])).to eq(true)
+      end
+
+      it "returns true if the args contain the required flag with equal" do
+        expect(acc.check(["--chef-license=accept"])).to eq(true)
+      end
+
+      it "returns false if the args do not contain the required value" do
+        expect(acc.check(["--chef-license"])).to eq(false)
+      end
     end
 
-    it "returns true if the args contain the required flag with equal" do
-      expect(acc.check(["--chef-license=accept"])).to eq(true)
+    describe "#silent?" do
+      it "returns false if the args contain the required flag with spaces" do
+        expect(acc.silent?(["--chef-license", "accept"])).to eq(false)
+      end
+
+      it "returns false if the args contain the required flag with equal" do
+        expect(acc.silent?(["--chef-license=accept"])).to eq(false)
+      end
+    end
+  end
+
+  describe "with a silent option" do
+    describe "#check" do
+      it "returns true if the args contain the required flag with spaces" do
+        expect(acc.check(["--chef-license", "accept-silent"])).to eq(true)
+      end
+
+      it "returns true if the args contain the required flag with equal" do
+        expect(acc.check(["--chef-license=accept-silent"])).to eq(true)
+      end
     end
 
-    it "returns false if the args do not contain the required value" do
-      expect(acc.check(["--chef-license"])).to eq(false)
+    describe "#silent?" do
+      it "returns true if the args contain the required flag with spaces" do
+        expect(acc.silent?(["--chef-license", "accept-silent"])).to eq(true)
+      end
+
+      it "returns true if the args contain the required flag with equal" do
+        expect(acc.silent?(["--chef-license=accept-silent"])).to eq(true)
+      end
     end
   end
 

--- a/components/ruby/spec/license_acceptance/arg_acceptance_spec.rb
+++ b/components/ruby/spec/license_acceptance/arg_acceptance_spec.rb
@@ -5,39 +5,19 @@ RSpec.describe LicenseAcceptance::ArgAcceptance do
   let(:acc) { LicenseAcceptance::ArgAcceptance.new }
 
   describe "with an accept option" do
-    describe "#check" do
+    describe "#accepted?" do
       it "returns true if the args contain the required flag with spaces" do
-        expect(acc.check(["--chef-license", "accept"])).to eq(true)
+        expect(acc.accepted?(["--chef-license", "accept"])).to eq(true)
       end
 
       it "returns true if the args contain the required flag with equal" do
-        expect(acc.check(["--chef-license=accept"])).to eq(true)
+        expect(acc.accepted?(["--chef-license=accept"])).to eq(true)
       end
 
       it "returns false if the args do not contain the required value" do
-        expect(acc.check(["--chef-license"])).to eq(false)
-      end
-    end
-
-    describe "#silent?" do
-      it "returns false if the args contain the required flag with spaces" do
-        expect(acc.silent?(["--chef-license", "accept"])).to eq(false)
-      end
-
-      it "returns false if the args contain the required flag with equal" do
-        expect(acc.silent?(["--chef-license=accept"])).to eq(false)
-      end
-    end
-  end
-
-  describe "with a silent option" do
-    describe "#check" do
-      it "returns true if the args contain the required flag with spaces" do
-        expect(acc.check(["--chef-license", "accept-silent"])).to eq(true)
-      end
-
-      it "returns true if the args contain the required flag with equal" do
-        expect(acc.check(["--chef-license=accept-silent"])).to eq(true)
+        expect(acc.accepted?(["--chef-license"])).to eq(false)
+        expect(acc.accepted?(["--chef-license=foo"])).to eq(false)
+        expect(acc.accepted?(["--chef-license", "foo"])).to eq(false)
       end
     end
 
@@ -49,22 +29,28 @@ RSpec.describe LicenseAcceptance::ArgAcceptance do
       it "returns true if the args contain the required flag with equal" do
         expect(acc.silent?(["--chef-license=accept-silent"])).to eq(true)
       end
+
+      it "returns false if the args do not contain the required value" do
+        expect(acc.silent?(["--chef-license"])).to eq(false)
+        expect(acc.silent?(["--chef-license=accept"])).to eq(false)
+        expect(acc.silent?(["--chef-license", "accept"])).to eq(false)
+      end
     end
   end
 
-  describe "#check_no_persist" do
+  describe "#no_persist?" do
     it "returns true if the args contain the required flag with spaces" do
-      expect(acc.check_no_persist(["--chef-license", "accept-no-persist"])).to eq(true)
+      expect(acc.no_persist?(["--chef-license", "accept-no-persist"])).to eq(true)
     end
 
     it "returns true if the args contain the required flag with equal" do
-      expect(acc.check_no_persist(["--chef-license=accept-no-persist"])).to eq(true)
+      expect(acc.no_persist?(["--chef-license=accept-no-persist"])).to eq(true)
     end
 
     it "returns false if the args do not contain the required value" do
-      expect(acc.check_no_persist(["--chef-license"])).to eq(false)
-      expect(acc.check_no_persist(["--chef-license=accept"])).to eq(false)
-      expect(acc.check_no_persist(["--chef-license","accept"])).to eq(false)
+      expect(acc.no_persist?(["--chef-license"])).to eq(false)
+      expect(acc.no_persist?(["--chef-license=accept"])).to eq(false)
+      expect(acc.no_persist?(["--chef-license", "accept"])).to eq(false)
     end
   end
 

--- a/components/ruby/spec/license_acceptance/env_acceptance_spec.rb
+++ b/components/ruby/spec/license_acceptance/env_acceptance_spec.rb
@@ -5,20 +5,20 @@ RSpec.describe LicenseAcceptance::EnvAcceptance do
   let(:acc) { LicenseAcceptance::EnvAcceptance.new }
 
   describe "when passed an accept value" do
-    describe "#check" do
+    describe "#accepted?" do
       it "returns true if the env contains the correct key and value" do
         env = {"CHEF_LICENSE" => "accept"}
-        expect(acc.check(env)).to eq(true)
+        expect(acc.accepted?(env)).to eq(true)
       end
 
       it "returns false if the env has a key but nil value" do
         env = {"CHEF_LICENSE" => nil}
-        expect(acc.check(env)).to eq(false)
+        expect(acc.accepted?(env)).to eq(false)
       end
 
       it "returns false if the env has a key but incorrect value" do
         env = {"CHEF_LICENSE" => "foo"}
-        expect(acc.check(env)).to eq(false)
+        expect(acc.accepted?(env)).to eq(false)
       end
     end
 
@@ -36,27 +36,29 @@ RSpec.describe LicenseAcceptance::EnvAcceptance do
       it "returns false if the env has a key but incorrect value" do
         env = {"CHEF_LICENSE" => "foo"}
         expect(acc.silent?(env)).to eq(false)
+        env = {"CHEF_LICENSE" => "accept"}
+        expect(acc.silent?(env)).to eq(false)
       end
     end
 
   end
 
-  describe "#check_no_persist" do
+  describe "#no_persist?" do
     it "returns true if the env contains the correct key and value" do
       env = {"CHEF_LICENSE" => "accept-no-persist"}
-      expect(acc.check_no_persist(env)).to eq(true)
+      expect(acc.no_persist?(env)).to eq(true)
     end
 
     it "returns false if the env has a key but nil value" do
       env = {"CHEF_LICENSE" => nil}
-      expect(acc.check_no_persist(env)).to eq(false)
+      expect(acc.no_persist?(env)).to eq(false)
     end
 
     it "returns false if the env has a key but incorrect value" do
       env = {"CHEF_LICENSE" => "foo"}
-      expect(acc.check_no_persist(env)).to eq(false)
+      expect(acc.no_persist?(env)).to eq(false)
       env = {"CHEF_LICENSE" => "accept"}
-      expect(acc.check_no_persist(env)).to eq(false)
+      expect(acc.no_persist?(env)).to eq(false)
     end
   end
 

--- a/components/ruby/spec/license_acceptance/env_acceptance_spec.rb
+++ b/components/ruby/spec/license_acceptance/env_acceptance_spec.rb
@@ -4,21 +4,41 @@ require "license_acceptance/env_acceptance"
 RSpec.describe LicenseAcceptance::EnvAcceptance do
   let(:acc) { LicenseAcceptance::EnvAcceptance.new }
 
-  describe "#check" do
-    it "returns true if the env contains the correct key and value" do
-      env = {"CHEF_LICENSE" => "accept"}
-      expect(acc.check(env)).to eq(true)
+  describe "when passed an accept value" do
+    describe "#check" do
+      it "returns true if the env contains the correct key and value" do
+        env = {"CHEF_LICENSE" => "accept"}
+        expect(acc.check(env)).to eq(true)
+      end
+
+      it "returns false if the env has a key but nil value" do
+        env = {"CHEF_LICENSE" => nil}
+        expect(acc.check(env)).to eq(false)
+      end
+
+      it "returns false if the env has a key but incorrect value" do
+        env = {"CHEF_LICENSE" => "foo"}
+        expect(acc.check(env)).to eq(false)
+      end
     end
 
-    it "returns false if the env has a key but nil value" do
-      env = {"CHEF_LICENSE" => nil}
-      expect(acc.check(env)).to eq(false)
+    describe "#silent?" do
+      it "returns true if the env contains the correct key and value" do
+        env = {"CHEF_LICENSE" => "accept-silent"}
+        expect(acc.silent?(env)).to eq(true)
+      end
+
+      it "returns false if the env has a key but nil value" do
+        env = {"CHEF_LICENSE" => nil}
+        expect(acc.silent?(env)).to eq(false)
+      end
+
+      it "returns false if the env has a key but incorrect value" do
+        env = {"CHEF_LICENSE" => "foo"}
+        expect(acc.silent?(env)).to eq(false)
+      end
     end
 
-    it "returns false if the env has a key but incorrect value" do
-      env = {"CHEF_LICENSE" => "foo"}
-      expect(acc.check(env)).to eq(false)
-    end
   end
 
   describe "#check_no_persist" do

--- a/components/ruby/spec/license_acceptance/file_acceptance_spec.rb
+++ b/components/ruby/spec/license_acceptance/file_acceptance_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe LicenseAcceptance::FileAcceptance do
     describe "when there is an existing license file" do
       it "returns an empty missing product list" do
         expect(File).to receive(:exist?).with(File.join(dir1, p1_filename)).and_return(true)
-        expect(acc.check(product_relationship)).to eq([])
+        expect(acc.accepted?(product_relationship)).to eq([])
       end
     end
 
@@ -31,7 +31,7 @@ RSpec.describe LicenseAcceptance::FileAcceptance do
       it "returns the product in the missing product list" do
         expect(File).to receive(:exist?).with(File.join(dir1, p1_filename)).and_return(false)
         expect(File).to receive(:exist?).with(File.join(dir2, p1_filename)).and_return(false)
-        expect(acc.check(product_relationship)).to eq([p1])
+        expect(acc.accepted?(product_relationship)).to eq([p1])
       end
     end
 


### PR DESCRIPTION
## Description

Adds a new value that can be passed as a value to `--chef-license` or as an ENV var: `accept-silent`. If this value is seen, the license is accepted, persisted to disk, but no count of accepted licenses is emitted to STDOUT.

This solves a critical path issue with the A2 team: we cannot break pure JSON on STDOUT.

attn: @vjeffrey 

## Related Issue

Closes #23.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
