### PR TITLE
Expeditor should be updating the Gemfile.lock after bumping version

### DIFF
--- a/.expeditor/update_version.sh
+++ b/.expeditor/update_version.sh
@@ -7,6 +7,9 @@
 set -evx
 
 sed -i -r "s/^(\s*)VERSION = \".+\"/\1VERSION = \"$(cat VERSION)\"/" components/ruby/lib/license_acceptance/version.rb
+cd components/ruby
+bundle update
+cd ../..
 sed -i -r "s/^pkg_version=.+\$/\pkg_version=$(cat VERSION)/" components/golang/habitat/plan.sh
 
 # Once Expeditor finshes executing this script, it will commit the changes and push

--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -44,6 +44,7 @@ steps:
     - cd /workdir/components/ruby
     - bundle install
     - bundle exec rspec
+  timeout_in_minutes: 15
   expeditor:
     executor:
       docker:

--- a/components/ruby/.gitignore
+++ b/components/ruby/.gitignore
@@ -9,3 +9,4 @@
 # rspec failure tracking
 .rspec_status
 license-acceptance-*.gem
+.bundle

--- a/components/ruby/Gemfile.lock
+++ b/components/ruby/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    license-acceptance (0.2.5)
+    license-acceptance (0.2.7)
       pastel (~> 0.7)
       tomlrb (~> 1.2)
       tty-box (~> 0.3)


### PR DESCRIPTION
## Description
Otherwise the version of the `license-acceptance` gem itself begins to drift

## Related Issue
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
