### PR TITLE
Require Ruby 2.4 or later

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -37,7 +37,3 @@ steps:
   expeditor:
     executor:
       docker:
-  timeout_in_minutes: 15
-  expeditor:
-    executor:
-      docker:

--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -37,13 +37,6 @@ steps:
   expeditor:
     executor:
       docker:
-- label: rspec 2.3
-  command:
-    - asdf install ruby 2.3.8
-    - asdf local ruby 2.3.8
-    - cd /workdir/components/ruby
-    - bundle install
-    - bundle exec rspec
   timeout_in_minutes: 15
   expeditor:
     executor:

--- a/components/ruby/license-acceptance.gemspec
+++ b/components/ruby/license-acceptance.gemspec
@@ -18,10 +18,12 @@ Gem::Specification.new do |spec|
 
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'pastel', "~> 0.7"
-  spec.add_dependency 'tomlrb', "~> 1.2"
-  spec.add_dependency 'tty-box', "~> 0.3"
-  spec.add_dependency 'tty-prompt', "~> 0.18"
+  spec.required_ruby_version = ">= 2.4"
+
+  spec.add_dependency "pastel", "~> 0.7"
+  spec.add_dependency "tomlrb", "~> 1.2"
+  spec.add_dependency "tty-box", "~> 0.3"
+  spec.add_dependency "tty-prompt", "~> 0.18"
 
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"


### PR DESCRIPTION
We shouldn't support EOL ruby 2.3 with this gem.

This requires we first merge in https://github.com/inspec/inspec/pull/3953