### PR TITLE
Don't test against Ruby 2.3 because it is EOL

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -37,14 +37,3 @@ steps:
   expeditor:
     executor:
       docker:
-- label: rspec 2.3
-  command:
-    - asdf install ruby 2.3.8
-    - asdf local ruby 2.3.8
-    - cd /workdir/components/ruby
-    - bundle install
-    - bundle exec rspec
-  timeout_in_minutes: 15
-  expeditor:
-    executor:
-      docker:


### PR DESCRIPTION
### Description

Thought we needed this for testing InSpec, but they are dropping support with the v4 release

### Issues Resolved

N/A

### Check List

- [x] New functionality includes tests
- [ ] All tests pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [x] PR title is a worthy inclusion in the CHANGELOG