### PR TITLE
Adding mixlib-install product search to enable Test Kitchen

### DIFF
--- a/components/ruby/README.md
+++ b/components/ruby/README.md
@@ -62,7 +62,7 @@ LicenseAcceptance::Acceptor.check_and_persist('inspec', Inspec::VERSION,
 * `license_locations` - Array of locations to search for existing licenses, defaults described in top level README
 * `persist_location` - Location to persist license marker files, should be one of the locations from `license_locations`
   if future reads are supposed to work
-* `persist` - Whether to persist the license marker files, setting is overwritten by `accept-no-license` acceptance
+* `persist` - Whether to persist the license marker files, setting is overwritten by `accept-no-persist` acceptance
   value.
 * `provided` - Acceptance value provided by the consumer of this library. Expected to be one of the supported values
   (`accept`, `accept-silent`, `accept-no-persist`) or it is ignored. Defaults to nil.

--- a/components/ruby/lib/license_acceptance/product.rb
+++ b/components/ruby/lib/license_acceptance/product.rb
@@ -1,19 +1,23 @@
 module LicenseAcceptance
   class Product
 
-    attr_reader :name, :pretty_name, :filename
+    attr_reader :name, :pretty_name, :filename, :mixlib_name, :license_required_version
 
-    def initialize(name, pretty_name, filename)
+    def initialize(name, pretty_name, filename, mixlib_name, license_required_version)
       @name = name
       @pretty_name = pretty_name
       @filename = filename
+      @mixlib_name = mixlib_name
+      @license_required_version = license_required_version
     end
 
     def ==(other)
       return false if other.class != Product
       if other.name == name &&
          other.pretty_name == pretty_name &&
-         other.filename == filename
+         other.filename == filename &&
+         other.mixlib_name == mixlib_name
+         other.license_required_version == license_required_version
          return true
       end
       return false

--- a/components/ruby/lib/license_acceptance/product_reader.rb
+++ b/components/ruby/lib/license_acceptance/product_reader.rb
@@ -19,7 +19,11 @@ module LicenseAcceptance
       raise InvalidProductInfo.new(location) if toml.empty? || toml["products"].nil? || toml["relationships"].nil?
 
       for product in toml["products"]
-        products[product["name"]] = Product.new(product["name"], product["pretty_name"], product["filename"])
+        products[product["name"]] = Product.new(
+          product["name"], product["pretty_name"],
+          product["filename"], product["mixlib_name"],
+          product["license_required_version"]
+        )
       end
 
       for parent_name, children in toml["relationships"]
@@ -60,6 +64,13 @@ module LicenseAcceptance
         raise ProductVersionTypeError.new(parent_version)
       end
       ProductRelationship.new(parent_product, children, parent_version)
+    end
+
+    def lookup_by_mixlib(mixlib_name)
+      found_product = products.values.find(nil) do |p|
+        p.mixlib_name == mixlib_name
+      end
+      found_product
     end
 
   end

--- a/components/ruby/lib/license_acceptance/strategy/base.rb
+++ b/components/ruby/lib/license_acceptance/strategy/base.rb
@@ -2,10 +2,6 @@ module LicenseAcceptance
   module Strategy
     class Base
 
-      ACCEPT = "accept"
-      ACCEPT_SILENT = "accept-silent"
-      ACCEPT_NO_PERSIST = "accept-no-persist"
-
     end
   end
 end

--- a/components/ruby/spec/license_acceptance/product_spec.rb
+++ b/components/ruby/spec/license_acceptance/product_spec.rb
@@ -2,12 +2,14 @@ require "spec_helper"
 require "license_acceptance/product"
 
 RSpec.describe LicenseAcceptance::Product do
-  let(:instance) { LicenseAcceptance::Product.new("name", "Pretty Name", "filename") }
+  let(:instance) { LicenseAcceptance::Product.new("name", "Pretty Name", "filename", "mixlib_name", "version") }
 
   it "can lookup the product attributes" do
     expect(instance.name).to eq("name")
     expect(instance.pretty_name).to eq("Pretty Name")
     expect(instance.filename).to eq("filename")
+    expect(instance.mixlib_name).to eq("mixlib_name")
+    expect(instance.license_required_version).to eq("version")
   end
 
 end

--- a/product_info.toml
+++ b/product_info.toml
@@ -5,6 +5,8 @@ name = "chef-client"
 pretty_name = "Chef Client"
 hab_pkg_id = "chef/chef-client"
 filename = "chef_client"
+mixlib_name = "chef"
+license_required_version = "15"
 
 [[products]]
 name = "inspec"


### PR DESCRIPTION
### Description

Test Kitchen knows products by their mixlib-install name so we add
support for that attribute to the product. We also expose methods to
interact with the products by that attribute. Finally, I added a
convenience method for Test Kitchen to know how the license was accepted
so it can pass that through to provisioned nodes.

### Issues Resolved

N/A

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG