### PR TITLE
Adding back Ruby 2.3 support to prevent major version bumping Test Kitchen

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -37,3 +37,13 @@ steps:
   expeditor:
     executor:
       docker:
+- label: rspec 2.3
+  command:
+    - asdf install ruby 2.3.8
+    - asdf local ruby 2.3.8
+    - cd /workdir/components/ruby
+    - bundle install
+    - bundle exec rspec
+  expeditor:
+    executor:
+      docker:

--- a/components/ruby/license-acceptance.gemspec
+++ b/components/ruby/license-acceptance.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
 
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = ">= 2.4"
+  spec.required_ruby_version = ">= 2.3"
 
   spec.add_dependency "pastel", "~> 0.7"
   spec.add_dependency "tomlrb", "~> 1.2"


### PR DESCRIPTION
### Check List

- [x] New functionality includes tests
- [ ] All tests pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [x] PR title is a worthy inclusion in the CHANGELOG