### PR TITLE
TK can provide nil version to license_required?

### DIFF
--- a/components/ruby/lib/license_acceptance/acceptor.rb
+++ b/components/ruby/lib/license_acceptance/acceptor.rb
@@ -103,7 +103,8 @@ module LicenseAcceptance
     def license_required?(mixlib_name, version)
       product = product_reader.lookup_by_mixlib(mixlib_name)
       return false if product.nil?
-      return true if version == :latest
+      # If they don't pass a version we assume they want latest
+      return true if version == :latest || version.nil?
       Gem::Version.new(version) >= Gem::Version.new(product.license_required_version)
     end
 


### PR DESCRIPTION
### Description

In this case we assume they want the latest version which will require a
license.

### Issues Resolved

N/A

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [x] PR title is a worthy inclusion in the CHANGELOG