### PR TITLE
Bringing names in line with marketing

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -47,3 +47,6 @@ steps:
   expeditor:
     executor:
       docker:
+    defaults:
+      buildkite:
+        timeout_in_minutes: 15

--- a/components/ruby/lib/license_acceptance/product.rb
+++ b/components/ruby/lib/license_acceptance/product.rb
@@ -1,10 +1,11 @@
 module LicenseAcceptance
   class Product
 
-    attr_reader :name, :pretty_name, :filename, :mixlib_name, :license_required_version
+    attr_reader :id, :pretty_name, :filename, :mixlib_name, :license_required_version
 
-    def initialize(name, pretty_name, filename, mixlib_name, license_required_version)
-      @name = name
+    def initialize(id, pretty_name, filename, mixlib_name, license_required_version)
+      # id is the internal representation of this product as license-acceptance knows it
+      @id = id
       @pretty_name = pretty_name
       @filename = filename
       @mixlib_name = mixlib_name
@@ -13,7 +14,7 @@ module LicenseAcceptance
 
     def ==(other)
       return false if other.class != Product
-      if other.name == name &&
+      if other.id == id &&
          other.pretty_name == pretty_name &&
          other.filename == filename &&
          other.mixlib_name == mixlib_name

--- a/components/ruby/lib/license_acceptance/product_reader.rb
+++ b/components/ruby/lib/license_acceptance/product_reader.rb
@@ -19,24 +19,24 @@ module LicenseAcceptance
       raise InvalidProductInfo.new(location) if toml.empty? || toml["products"].nil? || toml["relationships"].nil?
 
       for product in toml["products"]
-        products[product["name"]] = Product.new(
-          product["name"], product["pretty_name"],
+        products[product["id"]] = Product.new(
+          product["id"], product["pretty_name"],
           product["filename"], product["mixlib_name"],
           product["license_required_version"]
         )
       end
 
-      for parent_name, children in toml["relationships"]
-        parent = products[parent_name]
-        raise UnknownParent.new(parent_name) if parent.nil?
+      for parent_id, children in toml["relationships"]
+        parent = products[parent_id]
+        raise UnknownParent.new(parent_id) if parent.nil?
         # Its fine to not have a relationship entry, but not fine to have
         # a relationship where the children are nil or empty.
         if children.nil? || children.empty? || !children.is_a?(Array)
           raise NoChildRelationships.new(parent)
         end
-        children.map! do |child_name|
-          child = products[child_name]
-          raise UnknownChild.new(child_name) if child.nil?
+        children.map! do |child_id|
+          child = products[child_id]
+          raise UnknownChild.new(child_id) if child.nil?
           child
         end
         relationships[parent] = children
@@ -55,9 +55,9 @@ module LicenseAcceptance
       File.absolute_path(File.join(__FILE__, "../../../config/product_info.toml"))
     end
 
-    def lookup(parent_name, parent_version)
-      parent_product = products.fetch(parent_name) do
-        raise UnknownProduct.new(parent_name)
+    def lookup(parent_id, parent_version)
+      parent_product = products.fetch(parent_id) do
+        raise UnknownProduct.new(parent_id)
       end
       children = relationships.fetch(parent_product, [])
       if !parent_version.is_a? String
@@ -105,7 +105,7 @@ module LicenseAcceptance
 
   class NoChildRelationships < RuntimeError
     def initialize(product)
-      msg = "No child relationships for #{product.name}, should be removed from product info or fixed"
+      msg = "No child relationships for #{product.id}, should be removed from product info or fixed"
       super(msg)
     end
   end

--- a/components/ruby/lib/license_acceptance/strategy/file.rb
+++ b/components/ruby/lib/license_acceptance/strategy/file.rb
@@ -25,7 +25,7 @@ module LicenseAcceptance
       def accepted?(product_relationship)
         searching = [product_relationship.parent] + product_relationship.children
         missing_licenses = searching.clone
-        logger.debug("Searching for the following licenses: #{missing_licenses.map(&:name)}")
+        logger.debug("Searching for the following licenses: #{missing_licenses.map(&:id)}")
 
         searching.each do |product|
           found = false
@@ -40,7 +40,7 @@ module LicenseAcceptance
           end
           break if missing_licenses.empty?
         end
-        logger.debug("Missing licenses remaining: #{missing_licenses.map(&:name)}")
+        logger.debug("Missing licenses remaining: #{missing_licenses.map(&:id)}")
         missing_licenses
       end
 
@@ -77,12 +77,12 @@ module LicenseAcceptance
 
       def persist_license(folder_path, product, parent, parent_version)
         path = ::File.join(folder_path, product.filename)
-        logger.info("Persisting a license for #{product.name} at path #{path}")
+        logger.info("Persisting a license for #{product.pretty_name} at path #{path}")
         ::File.open(path, ::File::WRONLY | ::File::CREAT | ::File::EXCL) do |license_file|
           contents = {
-            name: product.name,
+            name: product.pretty_name,
             date_accepted: INVOCATION_TIME.iso8601,
-            accepting_product: parent.name,
+            accepting_product: parent.id,
             accepting_product_version: parent_version,
             user: Etc.getlogin,
             file_format: 1,

--- a/components/ruby/lib/license_acceptance/strategy/file.rb
+++ b/components/ruby/lib/license_acceptance/strategy/file.rb
@@ -80,6 +80,7 @@ module LicenseAcceptance
         logger.info("Persisting a license for #{product.pretty_name} at path #{path}")
         ::File.open(path, ::File::WRONLY | ::File::CREAT | ::File::EXCL) do |license_file|
           contents = {
+            id: product.id,
             name: product.pretty_name,
             date_accepted: INVOCATION_TIME.iso8601,
             accepting_product: parent.id,

--- a/components/ruby/lib/license_acceptance/strategy/prompt.rb
+++ b/components/ruby/lib/license_acceptance/strategy/prompt.rb
@@ -24,7 +24,7 @@ module LicenseAcceptance
       CHECK  = PASTEL.green("✔")
 
       def request(missing_licenses, &persist_callback)
-        logger.debug("Requesting a license for #{missing_licenses.map(&:name)}")
+        logger.debug("Requesting a license for #{missing_licenses.map(&:id)}")
         c = missing_licenses.size
         s = c > 1 ? "s": ""
 

--- a/components/ruby/spec/license_acceptance/acceptor_spec.rb
+++ b/components/ruby/spec/license_acceptance/acceptor_spec.rb
@@ -12,23 +12,28 @@ RSpec.describe LicenseAcceptance::Acceptor do
     d
   end
   let(:opts) { { output: output } }
+  let(:reader) { instance_double(LicenseAcceptance::ProductReader) }
   let(:acc) { LicenseAcceptance::Acceptor.new(opts) }
-  let(:product) { instance_double(LicenseAcceptance::Product, name: "chef-infra") }
+  let(:product) { instance_double(LicenseAcceptance::Product, id: "foo", pretty_name: "Foo") }
   let(:version) { "version" }
-  let(:relationship) { instance_double(LicenseAcceptance::ProductRelationship) }
+  let(:relationship) { instance_double(LicenseAcceptance::ProductRelationship, parent: product) }
   let(:missing) { [product] }
 
   describe "#check_and_persist!" do
-    let(:err) { LicenseAcceptance::LicenseNotAcceptedError.new([product]) }
+    before do
+      expect(LicenseAcceptance::ProductReader).to receive(:new).and_return(reader)
+      expect(reader).to receive(:read)
+    end
+
+    let(:err) { LicenseAcceptance::LicenseNotAcceptedError.new(product, [product]) }
     it "outputs an error message to stdout and exits when license acceptance is declined" do
       expect(acc).to receive(:check_and_persist).and_raise(err)
-      expect { acc.check_and_persist!(product.name, version) }.to raise_error(SystemExit)
-      expect(output.string).to match(/#{product.name}/)
+      expect { acc.check_and_persist!(product.id, version) }.to raise_error(SystemExit)
+      expect(output.string).to match(/#{product.pretty_name}/)
     end
   end
 
   describe "#check_and_persist" do
-    let(:reader) { instance_double(LicenseAcceptance::ProductReader) }
     let(:file_acc) { instance_double(LicenseAcceptance::Strategy::File) }
     let(:arg_acc) { instance_double(LicenseAcceptance::Strategy::Argument) }
     let(:prompt_acc) { instance_double(LicenseAcceptance::Strategy::Prompt) }
@@ -241,7 +246,7 @@ RSpec.describe LicenseAcceptance::Acceptor do
     let(:reader) { instance_double(LicenseAcceptance::ProductReader) }
     let(:mixlib_name) { "chef" }
     let(:version) { "15.0.0" }
-    let(:product) { instance_double(LicenseAcceptance::Product, name: "chef-infra", license_required_version: "15.0.0") }
+    let(:product) { instance_double(LicenseAcceptance::Product, id: "foo", license_required_version: "15.0.0") }
 
     before do
       expect(LicenseAcceptance::ProductReader).to receive(:new).and_return(reader)

--- a/components/ruby/spec/license_acceptance/product_reader_spec.rb
+++ b/components/ruby/spec/license_acceptance/product_reader_spec.rb
@@ -7,11 +7,11 @@ RSpec.describe LicenseAcceptance::ProductReader do
   let(:version) { "0.1.0" }
   let(:location) { "location" }
 
-  let(:p1) { {"name" => "p1", "pretty_name" => "P1", "filename" => "f1", "mixlib_name" => "p1m", "license_required_version" => "p1v"} }
-  let(:p2) { {"name" => "p2", "pretty_name" => "P2", "filename" => "f2", "mixlib_name" => "p2m", "license_required_version" => "p2v"} }
+  let(:p1) { {"id" => "p1", "pretty_name" => "P1", "filename" => "f1", "mixlib_name" => "p1m", "license_required_version" => "p1v"} }
+  let(:p2) { {"id" => "p2", "pretty_name" => "P2", "filename" => "f2", "mixlib_name" => "p2m", "license_required_version" => "p2v"} }
   # defined the `==` operator on Product for ease of comparison
-  let(:product1) { LicenseAcceptance::Product.new(p1["name"], p1["pretty_name"], p1["filename"], p1["mixlib_name"], p1["license_required_version"]) }
-  let(:product2) { LicenseAcceptance::Product.new(p2["name"], p2["pretty_name"], p2["filename"], p2["mixlib_name"], p2["license_required_version"]) }
+  let(:product1) { LicenseAcceptance::Product.new(p1["id"], p1["pretty_name"], p1["filename"], p1["mixlib_name"], p1["license_required_version"]) }
+  let(:product2) { LicenseAcceptance::Product.new(p2["id"], p2["pretty_name"], p2["filename"], p2["mixlib_name"], p2["license_required_version"]) }
   let(:r1) { {p1 => p2} }
   let(:toml) { {"products" => [p1, p2], "relationships" => {"p1" => ["p2"]}} }
 

--- a/components/ruby/spec/license_acceptance/product_spec.rb
+++ b/components/ruby/spec/license_acceptance/product_spec.rb
@@ -2,10 +2,10 @@ require "spec_helper"
 require "license_acceptance/product"
 
 RSpec.describe LicenseAcceptance::Product do
-  let(:instance) { LicenseAcceptance::Product.new("name", "Pretty Name", "filename", "mixlib_name", "version") }
+  let(:instance) { LicenseAcceptance::Product.new("id", "Pretty Name", "filename", "mixlib_name", "version") }
 
   it "can lookup the product attributes" do
-    expect(instance.name).to eq("name")
+    expect(instance.id).to eq("id")
     expect(instance.pretty_name).to eq("Pretty Name")
     expect(instance.filename).to eq("filename")
     expect(instance.mixlib_name).to eq("mixlib_name")

--- a/components/ruby/spec/license_acceptance/strategy/file_spec.rb
+++ b/components/ruby/spec/license_acceptance/strategy/file_spec.rb
@@ -44,6 +44,7 @@ RSpec.describe LicenseAcceptance::Strategy::File do
         expect(File).to receive(:open).with(File.join(dir3, p1_filename), mode).and_yield(file)
         expect(file).to receive(:<<) do |yaml|
           yaml = YAML.load(yaml)
+          expect(yaml["id"]).to eq(p1_id)
           expect(yaml["name"]).to eq(p1_pretty)
           expect(yaml["accepting_product"]).to eq(p1_id)
           expect(yaml["accepting_product_version"]).to eq(version)
@@ -70,6 +71,7 @@ RSpec.describe LicenseAcceptance::Strategy::File do
           expect(File).to receive(:open).with(File.join(dir3, p1_filename), mode).and_yield(file)
           expect(file).to receive(:<<) do |yaml|
             yaml = YAML.load(yaml)
+            expect(yaml["id"]).to eq(p1_id)
             expect(yaml["name"]).to eq(p1_pretty)
             expect(yaml["accepting_product"]).to eq(p1_id)
             expect(yaml["accepting_product_version"]).to eq(version)
@@ -77,6 +79,7 @@ RSpec.describe LicenseAcceptance::Strategy::File do
           expect(File).to receive(:open).with(File.join(dir3, p2_filename), mode).and_yield(file)
           expect(file).to receive(:<<) do |yaml|
             yaml = YAML.load(yaml)
+            expect(yaml["id"]).to eq(p2_id)
             expect(yaml["name"]).to eq(p2_pretty)
             expect(yaml["accepting_product"]).to eq(p1_id)
             expect(yaml["accepting_product_version"]).to eq(version)
@@ -90,6 +93,7 @@ RSpec.describe LicenseAcceptance::Strategy::File do
             expect(File).to receive(:open).once.with(File.join(dir3, p2_filename), mode).and_yield(file)
             expect(file).to receive(:<<) do |yaml|
               yaml = YAML.load(yaml)
+              expect(yaml["id"]).to eq(p2_id)
               expect(yaml["name"]).to eq(p2_pretty)
               expect(yaml["accepting_product"]).to eq(p1_id)
               expect(yaml["accepting_product_version"]).to eq(version)

--- a/components/ruby/spec/license_acceptance/strategy/file_spec.rb
+++ b/components/ruby/spec/license_acceptance/strategy/file_spec.rb
@@ -12,9 +12,10 @@ RSpec.describe LicenseAcceptance::Strategy::File do
     instance_double(LicenseAcceptance::Config, license_locations: [dir1, dir2], persist_location: dir3)
   end
   let(:acc) { LicenseAcceptance::Strategy::File.new(config) }
-  let(:p1_name) { "chef-infra" }
+  let(:p1_id) { "foo" }
   let(:p1_filename) { "p1_filename" }
-  let(:p1) { instance_double(LicenseAcceptance::Product, name: p1_name, filename: p1_filename) }
+  let(:p1_pretty) { "Pretty Name" }
+  let(:p1) { instance_double(LicenseAcceptance::Product, id: p1_id, filename: p1_filename, pretty_name: p1_pretty) }
   let(:version) { "0.1.0" }
   let(:product_relationship) { instance_double(LicenseAcceptance::ProductRelationship, parent: p1, children: [], parent_version: version) }
   let(:mode) { File::WRONLY | File::CREAT | File::EXCL }
@@ -43,17 +44,18 @@ RSpec.describe LicenseAcceptance::Strategy::File do
         expect(File).to receive(:open).with(File.join(dir3, p1_filename), mode).and_yield(file)
         expect(file).to receive(:<<) do |yaml|
           yaml = YAML.load(yaml)
-          expect(yaml["name"]).to eq(p1_name)
-          expect(yaml["accepting_product"]).to eq(p1_name)
+          expect(yaml["name"]).to eq(p1_pretty)
+          expect(yaml["accepting_product"]).to eq(p1_id)
           expect(yaml["accepting_product_version"]).to eq(version)
         end
         expect(acc.persist(product_relationship, [p1])).to eq([])
       end
 
       describe "when license has children" do
-        let(:p2_name) { "inspec" }
+        let(:p2_id) { "bar" }
         let(:p2_filename) { "p2_filename" }
-        let(:p2) { instance_double(LicenseAcceptance::Product, name: p2_name, filename: p2_filename) }
+        let(:p2_pretty) { "Other Pretty Name" }
+        let(:p2) { instance_double(LicenseAcceptance::Product, id: p2_id, filename: p2_filename, pretty_name: p2_pretty) }
         let(:product_relationship) {
           instance_double(
             LicenseAcceptance::ProductRelationship,
@@ -68,15 +70,15 @@ RSpec.describe LicenseAcceptance::Strategy::File do
           expect(File).to receive(:open).with(File.join(dir3, p1_filename), mode).and_yield(file)
           expect(file).to receive(:<<) do |yaml|
             yaml = YAML.load(yaml)
-            expect(yaml["name"]).to eq(p1_name)
-            expect(yaml["accepting_product"]).to eq(p1_name)
+            expect(yaml["name"]).to eq(p1_pretty)
+            expect(yaml["accepting_product"]).to eq(p1_id)
             expect(yaml["accepting_product_version"]).to eq(version)
           end
           expect(File).to receive(:open).with(File.join(dir3, p2_filename), mode).and_yield(file)
           expect(file).to receive(:<<) do |yaml|
             yaml = YAML.load(yaml)
-            expect(yaml["name"]).to eq(p2_name)
-            expect(yaml["accepting_product"]).to eq(p1_name)
+            expect(yaml["name"]).to eq(p2_pretty)
+            expect(yaml["accepting_product"]).to eq(p1_id)
             expect(yaml["accepting_product_version"]).to eq(version)
           end
           expect(acc.persist(product_relationship, [p1, p2])).to eq([])
@@ -88,8 +90,8 @@ RSpec.describe LicenseAcceptance::Strategy::File do
             expect(File).to receive(:open).once.with(File.join(dir3, p2_filename), mode).and_yield(file)
             expect(file).to receive(:<<) do |yaml|
               yaml = YAML.load(yaml)
-              expect(yaml["name"]).to eq(p2_name)
-              expect(yaml["accepting_product"]).to eq(p1_name)
+              expect(yaml["name"]).to eq(p2_pretty)
+              expect(yaml["accepting_product"]).to eq(p1_id)
               expect(yaml["accepting_product_version"]).to eq(version)
             end
             expect(acc.persist(product_relationship, [p2])).to eq([])

--- a/components/ruby/spec/license_acceptance/strategy/prompt_spec.rb
+++ b/components/ruby/spec/license_acceptance/strategy/prompt_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe LicenseAcceptance::Strategy::Prompt do
   end
   let(:acc) { LicenseAcceptance::Strategy::Prompt.new(config) }
   let(:prompt) { instance_double(TTY::Prompt) }
-  let(:p1) { instance_double(LicenseAcceptance::Product, name: "name", pretty_name: "Pretty Name") }
+  let(:p1) { instance_double(LicenseAcceptance::Product, id: "foo", pretty_name: "Pretty Name") }
   let(:missing_licenses) { [p1] }
 
   before do
@@ -29,7 +29,7 @@ RSpec.describe LicenseAcceptance::Strategy::Prompt do
     end
 
     describe "when there are multiple products" do
-      let(:p2) { instance_double(LicenseAcceptance::Product, name: "other_name", pretty_name: "Other") }
+      let(:p2) { instance_double(LicenseAcceptance::Product, id: "bar", pretty_name: "Other") }
       let(:missing_licenses) { [p1, p2] }
       it "returns true" do
         expect(prompt).to receive(:ask).and_return("yes")

--- a/product_info.toml
+++ b/product_info.toml
@@ -4,7 +4,7 @@ title = "All known products that require license acceptance, and the mapping of 
 id = "infra-client"
 pretty_name = "Chef Infra Client"
 hab_pkg_id = "chef/chef-client"
-filename = "infra_client"
+filename = "chef_infra_client"
 mixlib_name = "chef"
 license_required_version = "15"
 
@@ -23,7 +23,7 @@ filename = "supermarket"
 id = "infra-server"
 pretty_name = "Chef Infra Server"
 hab_pkg_id = "chef/oc_erchef"
-filename = "infra_server"
+filename = "chef_infra_server"
 
 [[products]]
 id = "push-jobs-server"

--- a/product_info.toml
+++ b/product_info.toml
@@ -1,36 +1,36 @@
 title = "All known products that require license acceptance, and the mapping of parent to child relationships"
 
 [[products]]
-name = "chef-infra"
-pretty_name = "Chef Infra"
+id = "infra-client"
+pretty_name = "Chef Infra Client"
 hab_pkg_id = "chef/chef-client"
-filename = "chef_infra"
+filename = "infra_client"
 mixlib_name = "chef"
 license_required_version = "15"
 
 [[products]]
-name = "inspec"
-pretty_name = "InSpec"
+id = "inspec"
+pretty_name = "Chef InSpec"
 hab_pkg_id = "chef/inspec"
 filename = "inspec"
 
 [[products]]
-name = "supermarket"
+id = "supermarket"
 pretty_name = "Supermarket"
 filename = "supermarket"
 
 [[products]]
-name = "chef-server"
-pretty_name = "Chef Server"
+id = "infra-server"
+pretty_name = "Chef Infra Server"
 hab_pkg_id = "chef/oc_erchef"
-filename = "chef_server"
+filename = "infra_server"
 
 [[products]]
-name = "push-jobs-server"
+id = "push-jobs-server"
 pretty_name = "Chef Push Jobs Server"
-filename = "chef_push_jobs_server"
+filename = "push_jobs_server"
 
 [relationships]
-"chef-infra" = ["inspec"]
-"chef-server" = ["chef-infra"]
-"push-jobs-server" = ["chef-infra", "chef-server"]
+"infra-client" = ["inspec"]
+"infra-server" = ["infra-client"]
+"push-jobs-server" = ["infra-client", "infra-server"]


### PR DESCRIPTION
### Description

This change started by updating the Infra products to `Chef Infra
Client` and `Chef Infra Server`.

In doing this I realized `name` was a bad identifier on the product and
changed it to `id`. This reflects the truth that this is an internal
identifier of a product. It could be a UUID but that would make other
developers jobs hard. `pretty_name` is the name we use when
communicating to users about these products.

### Issues Resolved

N/A

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [x] PR title is a worthy inclusion in the CHANGELOG