### PR TITLE
mixlib supplies channel names as versions to install

### DIFF
--- a/components/ruby/lib/license_acceptance/acceptor.rb
+++ b/components/ruby/lib/license_acceptance/acceptor.rb
@@ -104,7 +104,8 @@ module LicenseAcceptance
       product = product_reader.lookup_by_mixlib(mixlib_name)
       return false if product.nil?
       # If they don't pass a version we assume they want latest
-      return true if version.to_s == "latest" || version.nil?
+      # All versions in all channels require license acceptance
+      return true if ["latest", "unstable", "current", "stable"].include?(version.to_s) || version.nil?
       Gem::Version.new(version) >= Gem::Version.new(product.license_required_version)
     end
 

--- a/components/ruby/spec/license_acceptance/acceptor_spec.rb
+++ b/components/ruby/spec/license_acceptance/acceptor_spec.rb
@@ -266,11 +266,12 @@ RSpec.describe LicenseAcceptance::Acceptor do
       end
     end
 
-    describe "when version is 'latest'" do
-      let(:version) { "latest" }
-      it "returns true" do
-        expect(reader).to receive(:lookup_by_mixlib).with(mixlib_name).and_return product
-        expect(acc.license_required?(mixlib_name, version)).to eq(true)
+    ["latest", "unstable", "current", "stable"].each do |version|
+      describe "when version is '#{version}'" do
+        it "returns true" do
+          expect(reader).to receive(:lookup_by_mixlib).with(mixlib_name).and_return product
+          expect(acc.license_required?(mixlib_name, version)).to eq(true)
+        end
       end
     end
 


### PR DESCRIPTION
## Description
For example: https://github.com/chef/chef/blob/master/kitchen-tests/kitchen.yml#L6

Without this change those tests now throw an error when trying to read that version using `Gem::Version`

## Related Issue
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
