### PR TITLE
Updating default license location for Habitat on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,8 +159,8 @@ different location than other software in the Chef Software ecosystem:
     * If the user is root: `/hab/accepted_licenses/`
     * If the user is non-root: `~/.hab/accepted_licenses/`
 * On Windows:
-    * If the user is Administrator: `C:\hab\accepted_licenses\`
-    * If the user is not Administrator: `C:\Users\<username>\.hab\accepted_licenses\`
+    * If the user is Administrator: `C:\hab\accepted-licenses\`
+    * If the user is not Administrator: `C:\Users\<username>\.hab\accepted-licenses\`
 
 Similar to the Chef license locations, non-`Administrator`/`root` users will look in the `Administrator`/`root` location
 if it is not found in their default location.


### PR DESCRIPTION
Signed-off-by: Stuart Preston <stuart@chef.io>

## Description

Whilst Chef Infra Client and InSpec use `accepted_licenses`, Habitat uses `accepted-licenses`. This fixes the Readme to that effect for Windows. I have not tested this on other platforms.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
