### PR TITLE
Add inspec to chef-server deps

### DIFF
--- a/product_info.toml
+++ b/product_info.toml
@@ -51,7 +51,7 @@ license_required_version = "0.4"
 
 [relationships]
 "infra-client" = ["inspec"]
-"infra-server" = ["infra-client"]
+"infra-server" = ["infra-client", "inspec"]
 "push-jobs-server" = ["infra-client", "infra-server"]
 "push-jobs-client" = ["infra-client"]
 "chef-dk" = ["infra-client", "inspec"]


### PR DESCRIPTION
It appears that accepting chef client license doesn't transitively
accept inspec, and that's blocking chef-server-ctl. Add inspec.

Signed-off-by: Mark Anderson <mark@chef.io>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
