### PR TITLE
Limit the files we ship in the gem to reduce the install size

### DIFF
--- a/components/ruby/license-acceptance.gemspec
+++ b/components/ruby/license-acceptance.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/chef/license-acceptance/"
   spec.license       = "Apache-2.0"
 
-  spec.files         = %w{Gemfile Gemfile.lock Rakefile LICENSE} + Dir.glob("{lib,spec,config}/**/*")
+  spec.files         = %w{Gemfile LICENSE} + Dir.glob("{lib,config}/**/*")
 
   spec.require_paths = ["lib"]
 


### PR DESCRIPTION
Don't ship the specs, Rakefile, or Gemfile.lock in the gem artifact.

Signed-off-by: Tim Smith <tsmith@chef.io>