### PR TITLE
Fixing error with Expeditor update_version.sh script

### DIFF
--- a/.expeditor/update_version.sh
+++ b/.expeditor/update_version.sh
@@ -8,6 +8,7 @@ set -evx
 
 sed -i -r "s/^(\s*)VERSION = \".+\"/\1VERSION = \"$(cat VERSION)\"/" components/ruby/lib/license_acceptance/version.rb
 cd components/ruby
+bundle install
 bundle update license-acceptance
 cd ../..
 sed -i -r "s/^pkg_version=.+\$/\pkg_version=$(cat VERSION)/" components/golang/habitat/plan.sh

--- a/components/ruby/lib/license_acceptance/acceptor.rb
+++ b/components/ruby/lib/license_acceptance/acceptor.rb
@@ -74,7 +74,7 @@ module LicenseAcceptance
           end
         end
         @acceptance_value = accepted_silent? ? ACCEPT_SILENT : ACCEPT
-        return true
+        true
       elsif config.output.isatty && prompt_strategy.request(missing_licenses) do
           # We have to infer the acceptance value if they use the prompt to accept
         if config.persist
@@ -85,7 +85,7 @@ module LicenseAcceptance
           []
         end
       end
-        return true
+        true
       else
         raise LicenseNotAcceptedError.new(product_relationship.parent, missing_licenses)
       end


### PR DESCRIPTION
## Description
```
+ bundle update license-acceptance
This Bundle hasn't been installed yet. Run `bundle install` to update and
install the bundled gems.
```

## Related Issue
https://logs.cd.chef.co/raw/chef-license-acceptance-master-pull_request_merged-chef-license-acceptance-master-69-86cffa00-7e03-11ea-9fc0-8fc1e1f846b2

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
