### PR TITLE
Remove support for Ruby 2.3 and bump tty deps

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -9,6 +9,15 @@ steps:
       docker:
         image: ruby:2.6-buster
 
+- label: run-specs-ruby-2.4
+  command:
+    - cd /workdir/components/ruby
+    - ../../.expeditor/run_linux_tests.sh "rake spec"
+  expeditor:
+    executor:
+      docker:
+        image: ruby:2.4-buster
+
 - label: run-specs-ruby-2.5
   command:
     - cd /workdir/components/ruby

--- a/components/ruby/Gemfile
+++ b/components/ruby/Gemfile
@@ -4,3 +4,25 @@ git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 
 # Specify your gem's dependencies in license-acceptance.gemspec
 gemspec
+
+group :development do
+  gem "chefstyle", "1.2.1"
+  gem "climate_control", "~> 0.2"
+  gem "mixlib-cli", "~> 1.7"
+  gem "rake", ">= 10.1.0"
+  gem "rspec", "~> 3.0"
+  gem "thor", ">= 0.20", "< 2.0" # validate 2.0 when it ships
+end
+
+group :docs do
+  gem "yard"
+  gem "redcarpet"
+  gem "github-markup"
+end
+
+group :debug do
+  gem "pry"
+  gem "pry-byebug"
+  gem "pry-stack_explorer", "~> 0.4.0" # pin until we drop ruby < 2.6
+  gem "rb-readline"
+end

--- a/components/ruby/lib/license_acceptance/acceptor.rb
+++ b/components/ruby/lib/license_acceptance/acceptor.rb
@@ -76,7 +76,7 @@ module LicenseAcceptance
         @acceptance_value = accepted_silent? ? ACCEPT_SILENT : ACCEPT
         true
       elsif config.output.isatty && prompt_strategy.request(missing_licenses) do
-          # We have to infer the acceptance value if they use the prompt to accept
+        # We have to infer the acceptance value if they use the prompt to accept
         if config.persist
           @acceptance_value = ACCEPT # rubocop: disable Lint/AssignmentInCondition
           file_strategy.persist(product_relationship, missing_licenses)

--- a/components/ruby/lib/license_acceptance/cli_flags/mixlib_cli.rb
+++ b/components/ruby/lib/license_acceptance/cli_flags/mixlib_cli.rb
@@ -1,6 +1,6 @@
 begin
   require "mixlib/cli"
-rescue => exception
+rescue
   raise "Must have mixlib-cli gem installed to use this mixin"
 end
 

--- a/components/ruby/lib/license_acceptance/cli_flags/thor.rb
+++ b/components/ruby/lib/license_acceptance/cli_flags/thor.rb
@@ -1,6 +1,6 @@
 begin
   require "thor"
-rescue => exception
+rescue
   raise "Must have thor gem installed to use this mixin"
 end
 

--- a/components/ruby/lib/license_acceptance/product.rb
+++ b/components/ruby/lib/license_acceptance/product.rb
@@ -18,10 +18,11 @@ module LicenseAcceptance
       if other.id == id &&
           other.pretty_name == pretty_name &&
           other.filename == filename &&
-          other.mixlib_name == mixlib_name
-        other.license_required_version == license_required_version
+          other.mixlib_name == mixlib_name &&
+          other.license_required_version == license_required_version
         return true
       end
+
       false
     end
 

--- a/components/ruby/lib/license_acceptance/strategy/prompt.rb
+++ b/components/ruby/lib/license_acceptance/strategy/prompt.rb
@@ -78,7 +78,7 @@ module LicenseAcceptance
               q.modify :down, :trim
               q.required true
               q.messages[:required?] = "You must enter 'yes' or 'no'"
-              q.validate /^\s*(yes|no)\s*$/i
+              q.validate(/^\s*(yes|no)\s*$/i)
               q.messages[:valid?] = "You must enter 'yes' or 'no'"
             end
           end

--- a/components/ruby/license-acceptance.gemspec
+++ b/components/ruby/license-acceptance.gemspec
@@ -24,14 +24,4 @@ Gem::Specification.new do |spec|
   spec.add_dependency "tomlrb", "~> 1.2"
   spec.add_dependency "tty-box", "~> 0.6" # 0.6 resolves ruby 2.7 warnings
   spec.add_dependency "tty-prompt", "~> 0.20" # 0.20 resolves ruby 2.7 warnings
-
-  spec.add_development_dependency "rake", "~> 13.0"
-  spec.add_development_dependency "rspec", "~> 3.0"
-  spec.add_development_dependency "pry", "~> 0.12"
-  spec.add_development_dependency "pry-byebug", "~> 3.6"
-  spec.add_development_dependency "pry-stack_explorer", "~> 0.4"
-  spec.add_development_dependency "mixlib-cli", "~> 1.7"
-  spec.add_development_dependency "thor", ">= 0.20", "< 2.0" # validate 2.0 when it ships
-  spec.add_development_dependency "climate_control", "~> 0.2"
-  spec.add_development_dependency "chefstyle"
 end

--- a/components/ruby/license-acceptance.gemspec
+++ b/components/ruby/license-acceptance.gemspec
@@ -18,14 +18,12 @@ Gem::Specification.new do |spec|
 
   spec.require_paths = ["lib"]
 
-  # We must support Ruby 2.3 because TK 1.x still uses that. When that is EOL
-  # we can move to Ruby 2.4
-  spec.required_ruby_version = ">= 2.3"
+  spec.required_ruby_version = ">= 2.4"
 
   spec.add_dependency "pastel", "~> 0.7"
   spec.add_dependency "tomlrb", "~> 1.2"
-  spec.add_dependency "tty-box", "~> 0.3"
-  spec.add_dependency "tty-prompt", "~> 0.18"
+  spec.add_dependency "tty-box", "~> 0.6" # 0.6 resolves ruby 2.7 warnings
+  spec.add_dependency "tty-prompt", "~> 0.20" # 0.20 resolves ruby 2.7 warnings
 
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec", "~> 3.0"


### PR DESCRIPTION
Test Kitchen 1 shipped in DK 3, which is now EOL. We can drop support
for Ruby 2.3 at this point and do a major version bump. This also sets
new floors for the tty-box and tty-prompt gems to resolve warnings on
Ruby 2.7+

Signed-off-by: Tim Smith <tsmith@chef.io>