### PR TITLE
Add accepted license values to Thor helper.

### DIFF
--- a/components/ruby/lib/license_acceptance/cli_flags/thor.rb
+++ b/components/ruby/lib/license_acceptance/cli_flags/thor.rb
@@ -12,7 +12,8 @@ module LicenseAcceptance
       def self.included(klass)
         klass.class_option :chef_license,
           type: :string,
-          desc: "Accept the license for this product and any contained products: accept, accept-no-persist, accept-silent"
+          desc: "Accept the license for this product and any contained products",
+          enum: %w{accept accept-no-persist accept-silent}
       end
 
     end

--- a/components/ruby/spec/license_acceptance/cli_flags/thor_spec.rb
+++ b/components/ruby/spec/license_acceptance/cli_flags/thor_spec.rb
@@ -2,13 +2,42 @@ require "spec_helper"
 require "license_acceptance/cli_flags/thor"
 require "thor"
 
-class TestThorKlass < Thor
-  include LicenseAcceptance::CLIFlags::Thor
-end
-
 RSpec.describe LicenseAcceptance::CLIFlags::Thor do
-  let(:klass) { TestThorKlass.new }
+  let(:klass) do
+    Class.new(Thor) do
+      include LicenseAcceptance::CLIFlags::Thor
+    end
+  end
+
+  # Thor writes the usage information to STDOUT in each of the following tests.
+  around do |example|
+    original_stdout = STDOUT.dup
+    STDOUT.reopen(File::NULL)
+    example.call
+  ensure
+    STDOUT.reopen(original_stdout)
+    original_stdout.close
+  end
+
   it "adds the correct command line flag" do
-    expect(klass.class.class_options.keys).to eq([:chef_license])
+    expect(klass.class_options.keys).to eq([:chef_license])
+  end
+
+  %w(accept accept-no-persist accept-silent).each do |license_value|
+    it "does not warn when setting the flag to '#{license_value}'" do
+      msg = /Expected '--chef-license' to be one of accept, accept-no-persist, accept-silent/
+
+      expect {
+        klass.start(["--chef_license=#{license_value}"])
+      }.not_to output(msg).to_stderr
+    end
+  end
+
+  it "warns when setting the flag to unrecognized values" do
+    msg = /Expected '--chef-license' to be one of accept, accept-no-persist, accept-silent; got foo/
+
+    expect {
+      klass.start(["--chef_license=foo"])
+    }.to output(msg).to_stderr
   end
 end


### PR DESCRIPTION
Signed-off-by: Pete Higgins <pete@peterhiggins.org>

Adds the expected license acceptance values to the Thor helper to be more helpful in the case of specifying a bad option. Testing the Thor option setting did not seem very straightforward and the tests are kind of ugly.