### PR TITLE
Add accepted license values to Mixlib::CLI helper.

### DIFF
--- a/components/ruby/lib/license_acceptance/cli_flags/mixlib_cli.rb
+++ b/components/ruby/lib/license_acceptance/cli_flags/mixlib_cli.rb
@@ -12,7 +12,8 @@ module LicenseAcceptance
       def self.included(klass)
         klass.option :chef_license,
           long: "--chef-license ACCEPTANCE",
-          description: "Accept the license for this product and any contained products ('accept', 'accept-no-persist', or 'accept-silent')",
+          description: "Accept the license for this product and any contained products",
+          in: %w{accept accept-no-persist accept-silent},
           required: false
       end
 

--- a/components/ruby/spec/license_acceptance/cli_flags/mixlib_cli_spec.rb
+++ b/components/ruby/spec/license_acceptance/cli_flags/mixlib_cli_spec.rb
@@ -1,14 +1,30 @@
 require "spec_helper"
 require "license_acceptance/cli_flags/mixlib_cli"
 
-class TestMixlibKlass
-  include Mixlib::CLI
-  include LicenseAcceptance::CLIFlags::MixlibCLI
-end
-
 RSpec.describe LicenseAcceptance::CLIFlags::MixlibCLI do
-  let(:klass) { TestMixlibKlass.new }
+  let(:klass) do
+    Class.new do
+      include Mixlib::CLI
+      include LicenseAcceptance::CLIFlags::MixlibCLI
+    end.new
+  end
+
   it "adds the correct command line flag" do
     expect(klass.options).to include(:chef_license)
+  end
+
+  %w{accept accept-no-persist accept-silent}.each do |license_value|
+    it "allows setting the flag to '#{license_value}'" do
+      klass.parse_options(["--chef-license", license_value])
+      expect(klass.config[:chef_license]).to eq(license_value)
+    end
+  end
+
+  it "does not allow setting the flag to unrecognized values" do
+    msg = /--chef-license: foo is not one of the allowed values: 'accept', 'accept-no-persist', or 'accept-silent'/
+
+    expect {
+      klass.parse_options(["--chef-license", "foo"])
+    }.to raise_error(SystemExit).and output(msg).to_stdout
   end
 end


### PR DESCRIPTION
Signed-off-by: Pete Higgins <pete@peterhiggins.org>

Adds the expected license acceptance values to the Mixlib::CLI helper to be more helpful in the case of specifying a bad option. 