### PR TITLE
Fail license acceptance if the user provides an unrecognized value

### DIFF
--- a/components/ruby/example/example_mixlib_cli_app.rb
+++ b/components/ruby/example/example_mixlib_cli_app.rb
@@ -1,0 +1,48 @@
+#!/usr/bin/env ruby
+
+$LOAD_PATH.unshift File.join(File.expand_path("..", __dir__), "lib/")
+
+require "mixlib/cli"
+require "license_acceptance/acceptor"
+require "license_acceptance/cli_flags/mixlib_cli"
+require "logger"
+
+class ExampleMixlibCLIApp
+  include Mixlib::CLI
+  include LicenseAcceptance::CLIFlags::MixlibCLI
+
+  option :help,
+    short: "-h",
+    long: "--help",
+    description: "Show this message",
+    on: :tail,
+    boolean: true,
+    show_options: true,
+    exit: 0
+
+  def run(argv = ARGV)
+    unless ARGV.include?("--help") || ARGV.include?("-h")
+      options = {}
+
+      if ENV["LOG_LEVEL"]
+        logger = Logger.new(STDOUT)
+        logger.level = ENV["LOG_LEVEL"]
+
+        options[:logger] = logger
+      end
+
+      if ENV["DEBUG_LICENSE"]
+        options[:provided] = ENV["DEBUG_LICENSE"]
+      end
+
+      LicenseAcceptance::Acceptor.check_and_persist!("infra-client", "1337", options)
+    end
+
+    parse_options(argv)
+  end
+end
+
+cli = ExampleMixlibCLIApp.new
+cli.run
+
+puts "BIG SUCCESS"

--- a/components/ruby/lib/license_acceptance/acceptor.rb
+++ b/components/ruby/lib/license_acceptance/acceptor.rb
@@ -79,7 +79,7 @@ module LicenseAcceptance
 
       if acceptance_value_provided?
         value = provided_strategy.value || env_strategy.value || arg_strategy.value
-        logger.error("Unrecognized license acceptance value '#{value}', expected one of: '#{ACCEPT}', '#{ACCEPT_SILENT}', '#{ACCEPT_NO_PERSIST}'")
+        output.puts("Unrecognized license acceptance value '#{value}', expected one of: '#{ACCEPT}', '#{ACCEPT_SILENT}', '#{ACCEPT_NO_PERSIST}'")
         raise LicenseNotAcceptedError.new(product_relationship.parent, missing_licenses)
       end
 

--- a/components/ruby/lib/license_acceptance/acceptor.rb
+++ b/components/ruby/lib/license_acceptance/acceptor.rb
@@ -78,7 +78,8 @@ module LicenseAcceptance
       end
 
       if acceptance_value_provided?
-        logger.error("License acceptance value is unrecognized, must be one of: '#{ACCEPT}', '#{ACCEPT_SILENT}', '#{ACCEPT_NO_PERSIST}'")
+        value = provided_strategy.value || env_strategy.value || arg_strategy.value
+        logger.error("Unrecognized license acceptance value '#{value}', expected one of: '#{ACCEPT}', '#{ACCEPT_SILENT}', '#{ACCEPT_NO_PERSIST}'")
         raise LicenseNotAcceptedError.new(product_relationship.parent, missing_licenses)
       end
 

--- a/components/ruby/lib/license_acceptance/acceptor.rb
+++ b/components/ruby/lib/license_acceptance/acceptor.rb
@@ -77,7 +77,7 @@ module LicenseAcceptance
         return true
       end
 
-      if unrecognized_acceptance_value?
+      if acceptance_value_provided?
         logger.error("License acceptance value is unrecognized, must be one of: '#{ACCEPT}', '#{ACCEPT_SILENT}', '#{ACCEPT_NO_PERSIST}'")
         raise LicenseNotAcceptedError.new(product_relationship.parent, missing_licenses)
       end
@@ -149,7 +149,7 @@ module LicenseAcceptance
       provided_strategy.silent? || env_strategy.silent? || arg_strategy.silent?
     end
 
-    def unrecognized_acceptance_value?
+    def acceptance_value_provided?
       provided_strategy.value? || env_strategy.value? || arg_strategy.value?
     end
 

--- a/components/ruby/lib/license_acceptance/acceptor.rb
+++ b/components/ruby/lib/license_acceptance/acceptor.rb
@@ -99,10 +99,10 @@ module LicenseAcceptance
       prompt_strategy.request(missing_licenses) do
         # We have to infer the acceptance value if they use the prompt to accept
         if config.persist
-          @acceptance_value = ACCEPT # rubocop: disable Lint/AssignmentInCondition
+          @acceptance_value = ACCEPT
           file_strategy.persist(product_relationship, missing_licenses)
         else
-          @acceptance_value = ACCEPT_NO_PERSIST # rubocop: disable Lint/AssignmentInCondition
+          @acceptance_value = ACCEPT_NO_PERSIST
           []
         end
       end

--- a/components/ruby/lib/license_acceptance/strategy/argument.rb
+++ b/components/ruby/lib/license_acceptance/strategy/argument.rb
@@ -15,36 +15,30 @@ module LicenseAcceptance
       end
 
       def accepted?
-        look_for_value(ACCEPT)
+        String(value).downcase == ACCEPT
       end
 
       def silent?
-        look_for_value(ACCEPT_SILENT)
+        String(value).downcase == ACCEPT_SILENT
       end
 
       def no_persist?
-        look_for_value(ACCEPT_NO_PERSIST)
+        String(value).downcase == ACCEPT_NO_PERSIST
       end
 
       def value?
         argv.any? { |s| s == FLAG || s.start_with?("#{FLAG}=") }
       end
 
-      private
+      def value
+        match = argv.detect { |s| s.start_with?("#{FLAG}=") }
+        return match.split("=").last if match
 
-      def look_for_value(sought)
-        if argv.include?("#{FLAG}=#{sought}")
-          return true
+        argv.each_cons(2) do |arg, value|
+          return value if arg == FLAG
         end
 
-        i = argv.index(FLAG)
-        unless i.nil?
-          val = argv[i + 1]
-          if !val.nil? && val.downcase == sought
-            return true
-          end
-        end
-        false
+        nil
       end
     end
   end

--- a/components/ruby/lib/license_acceptance/strategy/argument.rb
+++ b/components/ruby/lib/license_acceptance/strategy/argument.rb
@@ -6,6 +6,8 @@ module LicenseAcceptance
     # Look for acceptance values in the ARGV
     class Argument < Base
 
+      FLAG = "--chef-license".freeze
+
       attr_reader :argv
 
       def initialize(argv)
@@ -24,14 +26,18 @@ module LicenseAcceptance
         look_for_value(ACCEPT_NO_PERSIST)
       end
 
+      def value?
+        argv.any? { |s| s == FLAG || s.start_with?("#{FLAG}=") }
+      end
+
       private
 
       def look_for_value(sought)
-        if argv.include?("--chef-license=#{sought}")
+        if argv.include?("#{FLAG}=#{sought}")
           return true
         end
 
-        i = argv.index("--chef-license")
+        i = argv.index(FLAG)
         unless i.nil?
           val = argv[i + 1]
           if !val.nil? && val.downcase == sought

--- a/components/ruby/lib/license_acceptance/strategy/environment.rb
+++ b/components/ruby/lib/license_acceptance/strategy/environment.rb
@@ -15,29 +15,23 @@ module LicenseAcceptance
       end
 
       def accepted?
-        look_for_value(ACCEPT)
+        String(value).downcase == ACCEPT
       end
 
       def silent?
-        look_for_value(ACCEPT_SILENT)
+        String(value).downcase == ACCEPT_SILENT
       end
 
       def no_persist?
-        look_for_value(ACCEPT_NO_PERSIST)
+        String(value).downcase == ACCEPT_NO_PERSIST
       end
 
       def value?
         env.key?(ENV_KEY)
       end
 
-      private
-
-      def look_for_value(sought)
-        if env[ENV_KEY] && env[ENV_KEY].downcase == sought
-          return true
-        end
-
-        false
+      def value
+        env[ENV_KEY]
       end
 
     end

--- a/components/ruby/lib/license_acceptance/strategy/environment.rb
+++ b/components/ruby/lib/license_acceptance/strategy/environment.rb
@@ -6,6 +6,8 @@ module LicenseAcceptance
     # Look for acceptance values in the environment
     class Environment < Base
 
+      ENV_KEY = "CHEF_LICENSE".freeze
+
       attr_reader :env
 
       def initialize(env)
@@ -24,10 +26,14 @@ module LicenseAcceptance
         look_for_value(ACCEPT_NO_PERSIST)
       end
 
+      def value?
+        env.key?(ENV_KEY)
+      end
+
       private
 
       def look_for_value(sought)
-        if env["CHEF_LICENSE"] && env["CHEF_LICENSE"].downcase == sought
+        if env[ENV_KEY] && env[ENV_KEY].downcase == sought
           return true
         end
 

--- a/components/ruby/lib/license_acceptance/strategy/provided_value.rb
+++ b/components/ruby/lib/license_acceptance/strategy/provided_value.rb
@@ -22,7 +22,10 @@ module LicenseAcceptance
       def no_persist?
         value == ACCEPT_NO_PERSIST
       end
-    end
 
+      def value?
+        !!value
+      end
+    end
   end
 end

--- a/components/ruby/spec/license_acceptance/acceptor_spec.rb
+++ b/components/ruby/spec/license_acceptance/acceptor_spec.rb
@@ -95,7 +95,7 @@ RSpec.describe LicenseAcceptance::Acceptor do
         expect(prompt_acc).to_not receive(:request)
         expect(provided_acc).to receive(:value?).and_return(true)
         expect(provided_acc).to receive(:value).and_return("some-string")
-        expect(acc.logger).to receive(:error).with("Unrecognized license acceptance value 'some-string', expected one of: 'accept', 'accept-silent', 'accept-no-persist'")
+        expect(output).to receive(:puts).with("Unrecognized license acceptance value 'some-string', expected one of: 'accept', 'accept-silent', 'accept-no-persist'")
         expect { acc.check_and_persist(product, version) }.to raise_error(LicenseAcceptance::LicenseNotAcceptedError)
         expect(acc.acceptance_value).to eq(nil)
       end
@@ -158,7 +158,7 @@ RSpec.describe LicenseAcceptance::Acceptor do
           expect(prompt_acc).to_not receive(:request)
           expect(env_acc).to receive(:value?).and_return(true)
           expect(env_acc).to receive(:value).and_return("some-string")
-          expect(acc.logger).to receive(:error).with("Unrecognized license acceptance value 'some-string', expected one of: 'accept', 'accept-silent', 'accept-no-persist'")
+          expect(output).to receive(:puts).with("Unrecognized license acceptance value 'some-string', expected one of: 'accept', 'accept-silent', 'accept-no-persist'")
           expect { acc.check_and_persist(product, version) }.to raise_error(LicenseAcceptance::LicenseNotAcceptedError)
           expect(acc.acceptance_value).to eq(nil)
         end
@@ -222,7 +222,7 @@ RSpec.describe LicenseAcceptance::Acceptor do
           expect(arg_acc).to receive(:value?).and_return(true)
           expect(arg_acc).to receive(:value).and_return("some-string")
           expect(prompt_acc).to_not receive(:request)
-          expect(acc.logger).to receive(:error).with("Unrecognized license acceptance value 'some-string', expected one of: 'accept', 'accept-silent', 'accept-no-persist'")
+          expect(output).to receive(:puts).with("Unrecognized license acceptance value 'some-string', expected one of: 'accept', 'accept-silent', 'accept-no-persist'")
           expect { acc.check_and_persist(product, version) }.to raise_error(LicenseAcceptance::LicenseNotAcceptedError)
           expect(acc.acceptance_value).to eq(nil)
         end

--- a/components/ruby/spec/license_acceptance/acceptor_spec.rb
+++ b/components/ruby/spec/license_acceptance/acceptor_spec.rb
@@ -48,9 +48,9 @@ RSpec.describe LicenseAcceptance::Acceptor do
       expect(LicenseAcceptance::Strategy::Environment).to receive(:new).and_return(env_acc)
       expect(LicenseAcceptance::Strategy::ProvidedValue).to receive(:new).and_return(provided_acc)
 
-      allow(arg_acc).to receive_messages(accepted?: false, no_persist?: false, silent?: false, value?: false)
-      allow(env_acc).to receive_messages(accepted?: false, no_persist?: false, silent?: false, value?: false)
-      allow(provided_acc).to receive_messages(accepted?: false, no_persist?: false, silent?: false, value?: false)
+      allow(arg_acc).to receive_messages(accepted?: false, no_persist?: false, silent?: false, value: nil, value?: false)
+      allow(env_acc).to receive_messages(accepted?: false, no_persist?: false, silent?: false, value: nil, value?: false)
+      allow(provided_acc).to receive_messages(accepted?: false, no_persist?: false, silent?: false, value: nil, value?: false)
 
       expect(reader).to receive(:read)
     end
@@ -94,7 +94,8 @@ RSpec.describe LicenseAcceptance::Acceptor do
         expect(file_acc).to receive(:accepted?).with(relationship).and_return(missing)
         expect(prompt_acc).to_not receive(:request)
         expect(provided_acc).to receive(:value?).and_return(true)
-        expect(acc.logger).to receive(:error).with("License acceptance value is unrecognized, must be one of: 'accept', 'accept-silent', 'accept-no-persist'")
+        expect(provided_acc).to receive(:value).and_return("some-string")
+        expect(acc.logger).to receive(:error).with("Unrecognized license acceptance value 'some-string', expected one of: 'accept', 'accept-silent', 'accept-no-persist'")
         expect { acc.check_and_persist(product, version) }.to raise_error(LicenseAcceptance::LicenseNotAcceptedError)
         expect(acc.acceptance_value).to eq(nil)
       end
@@ -156,7 +157,8 @@ RSpec.describe LicenseAcceptance::Acceptor do
           expect(file_acc).to receive(:accepted?).with(relationship).and_return(missing)
           expect(prompt_acc).to_not receive(:request)
           expect(env_acc).to receive(:value?).and_return(true)
-          expect(acc.logger).to receive(:error).with("License acceptance value is unrecognized, must be one of: 'accept', 'accept-silent', 'accept-no-persist'")
+          expect(env_acc).to receive(:value).and_return("some-string")
+          expect(acc.logger).to receive(:error).with("Unrecognized license acceptance value 'some-string', expected one of: 'accept', 'accept-silent', 'accept-no-persist'")
           expect { acc.check_and_persist(product, version) }.to raise_error(LicenseAcceptance::LicenseNotAcceptedError)
           expect(acc.acceptance_value).to eq(nil)
         end
@@ -218,8 +220,9 @@ RSpec.describe LicenseAcceptance::Acceptor do
           expect(reader).to receive(:lookup).with(product, version).and_return(relationship)
           expect(file_acc).to receive(:accepted?).with(relationship).and_return(missing)
           expect(arg_acc).to receive(:value?).and_return(true)
+          expect(arg_acc).to receive(:value).and_return("some-string")
           expect(prompt_acc).to_not receive(:request)
-          expect(acc.logger).to receive(:error).with("License acceptance value is unrecognized, must be one of: 'accept', 'accept-silent', 'accept-no-persist'")
+          expect(acc.logger).to receive(:error).with("Unrecognized license acceptance value 'some-string', expected one of: 'accept', 'accept-silent', 'accept-no-persist'")
           expect { acc.check_and_persist(product, version) }.to raise_error(LicenseAcceptance::LicenseNotAcceptedError)
           expect(acc.acceptance_value).to eq(nil)
         end

--- a/components/ruby/spec/license_acceptance/acceptor_spec.rb
+++ b/components/ruby/spec/license_acceptance/acceptor_spec.rb
@@ -48,15 +48,9 @@ RSpec.describe LicenseAcceptance::Acceptor do
       expect(LicenseAcceptance::Strategy::Environment).to receive(:new).and_return(env_acc)
       expect(LicenseAcceptance::Strategy::ProvidedValue).to receive(:new).and_return(provided_acc)
 
-      allow(provided_acc).to receive(:no_persist?).and_return(false)
-      allow(env_acc).to receive(:no_persist?).and_return(false)
-      allow(arg_acc).to receive(:no_persist?).and_return(false)
-      allow(provided_acc).to receive(:accepted?).and_return(false)
-      allow(env_acc).to receive(:accepted?).and_return(false)
-      allow(arg_acc).to receive(:accepted?).and_return(false)
-      allow(provided_acc).to receive(:silent?).and_return(false)
-      allow(env_acc).to receive(:silent?).and_return(false)
-      allow(arg_acc).to receive(:silent?).and_return(false)
+      allow(arg_acc).to receive_messages(accepted?: false, no_persist?: false, silent?: false, value?: false)
+      allow(env_acc).to receive_messages(accepted?: false, no_persist?: false, silent?: false, value?: false)
+      allow(provided_acc).to receive_messages(accepted?: false, no_persist?: false, silent?: false, value?: false)
 
       expect(reader).to receive(:read)
     end
@@ -91,6 +85,18 @@ RSpec.describe LicenseAcceptance::Acceptor do
         expect(file_acc).to receive(:accepted?).with(relationship).and_return([])
         expect(acc.check_and_persist(product, version)).to eq(true)
         expect(acc.acceptance_value).to eq(LicenseAcceptance::ACCEPT)
+      end
+    end
+
+    describe "when an unrecognized value is provided from the caller" do
+      it "raises a LicenseNotAcceptedError error" do
+        expect(reader).to receive(:lookup).with(product, version).and_return(relationship)
+        expect(file_acc).to receive(:accepted?).with(relationship).and_return(missing)
+        expect(prompt_acc).to_not receive(:request)
+        expect(provided_acc).to receive(:value?).and_return(true)
+        expect(acc.logger).to receive(:error).with("License acceptance value is unrecognized, must be one of: 'accept', 'accept-silent', 'accept-no-persist'")
+        expect { acc.check_and_persist(product, version) }.to raise_error(LicenseAcceptance::LicenseNotAcceptedError)
+        expect(acc.acceptance_value).to eq(nil)
       end
     end
 
@@ -143,6 +149,18 @@ RSpec.describe LicenseAcceptance::Acceptor do
           expect(acc.acceptance_value).to eq(LicenseAcceptance::ACCEPT)
         end
       end
+
+      describe "when an unrecognized value is provided" do
+        it "raises a LicenseNotAcceptedError error" do
+          expect(reader).to receive(:lookup).with(product, version).and_return(relationship)
+          expect(file_acc).to receive(:accepted?).with(relationship).and_return(missing)
+          expect(prompt_acc).to_not receive(:request)
+          expect(env_acc).to receive(:value?).and_return(true)
+          expect(acc.logger).to receive(:error).with("License acceptance value is unrecognized, must be one of: 'accept', 'accept-silent', 'accept-no-persist'")
+          expect { acc.check_and_persist(product, version) }.to raise_error(LicenseAcceptance::LicenseNotAcceptedError)
+          expect(acc.acceptance_value).to eq(nil)
+        end
+      end
     end
 
     describe "when the user accepts as an arg" do
@@ -192,6 +210,18 @@ RSpec.describe LicenseAcceptance::Acceptor do
           expect(acc.check_and_persist(product, version)).to eq(true)
           expect(output.string).to match(/Could not persist acceptance:/)
           expect(acc.acceptance_value).to eq(LicenseAcceptance::ACCEPT)
+        end
+      end
+
+      describe "when an unrecognized value is provided" do
+        it "raises a LicenseNotAcceptedError error" do
+          expect(reader).to receive(:lookup).with(product, version).and_return(relationship)
+          expect(file_acc).to receive(:accepted?).with(relationship).and_return(missing)
+          expect(arg_acc).to receive(:value?).and_return(true)
+          expect(prompt_acc).to_not receive(:request)
+          expect(acc.logger).to receive(:error).with("License acceptance value is unrecognized, must be one of: 'accept', 'accept-silent', 'accept-no-persist'")
+          expect { acc.check_and_persist(product, version) }.to raise_error(LicenseAcceptance::LicenseNotAcceptedError)
+          expect(acc.acceptance_value).to eq(nil)
         end
       end
     end

--- a/components/ruby/spec/license_acceptance/strategy/argument_spec.rb
+++ b/components/ruby/spec/license_acceptance/strategy/argument_spec.rb
@@ -108,4 +108,34 @@ RSpec.describe LicenseAcceptance::Strategy::Argument do
       end
     end
   end
+
+  describe "#value" do
+    describe "when value is space separated" do
+      let(:argv) { ["--chef-license", "any-value"] }
+      it "returns the value" do
+        expect(acc.value).to eq("any-value")
+      end
+    end
+
+    describe "when the value is equal separated" do
+      let(:argv) { ["--chef-license=any-value"] }
+      it "returns the value" do
+        expect(acc.value).to eq("any-value")
+      end
+    end
+
+    describe "when no value is present" do
+      let(:argv) { ["--chef-license"] }
+      it "returns nil" do
+        expect(acc.value).to eq(nil)
+      end
+    end
+
+    describe "when the required flag is not present" do
+      let(:argv) { ["--chef-license-acceptance=yes"] }
+      it "returns nil" do
+        expect(acc.value).to eq(nil)
+      end
+    end
+  end
 end

--- a/components/ruby/spec/license_acceptance/strategy/argument_spec.rb
+++ b/components/ruby/spec/license_acceptance/strategy/argument_spec.rb
@@ -79,4 +79,33 @@ RSpec.describe LicenseAcceptance::Strategy::Argument do
     end
   end
 
+  describe "#value?" do
+    describe "when value is space separated" do
+      let(:argv) { ["--chef-license", "any-value"] }
+      it "returns true if the required flag is present" do
+        expect(acc.value?).to eq(true)
+      end
+    end
+
+    describe "when the value is equal separated" do
+      let(:argv) { ["--chef-license=any-value"] }
+      it "returns true if the required flag is present" do
+        expect(acc.value?).to eq(true)
+      end
+    end
+
+    describe "when no value is present" do
+      let(:argv) { ["--chef-license"] }
+      it "returns true if the required flag is present" do
+        expect(acc.value?).to eq(true)
+      end
+    end
+
+    describe "when the required flag is not present" do
+      let(:argv) { ["--chef-license-acceptance=yes"] }
+      it "returns false" do
+        expect(acc.value?).to eq(false)
+      end
+    end
+  end
 end

--- a/components/ruby/spec/license_acceptance/strategy/environment_spec.rb
+++ b/components/ruby/spec/license_acceptance/strategy/environment_spec.rb
@@ -73,4 +73,26 @@ RSpec.describe LicenseAcceptance::Strategy::Environment do
     end
   end
 
+  describe "#value?" do
+    describe "when the environment contains the correct key" do
+      let(:env) { { "CHEF_LICENSE" => "any-value" } }
+      it "returns true" do
+        expect(acc.value?).to eq(true)
+      end
+    end
+
+    describe "when the environment contains the correct key but nil value" do
+      let(:env) { { "CHEF_LICENSE" => nil } }
+      it "returns true" do
+        expect(acc.value?).to eq(true)
+      end
+    end
+
+    describe "when the environment does not contain the correct key" do
+      let(:env) { { "CHEF_LICENSE_ACCEPTANCE" => "any-value" } }
+      it "returns false" do
+        expect(acc.value?).to eq(false)
+      end
+    end
+  end
 end

--- a/components/ruby/spec/license_acceptance/strategy/environment_spec.rb
+++ b/components/ruby/spec/license_acceptance/strategy/environment_spec.rb
@@ -95,4 +95,27 @@ RSpec.describe LicenseAcceptance::Strategy::Environment do
       end
     end
   end
+
+  describe "#value" do
+    describe "when the environment contains the correct key" do
+      let(:env) { { "CHEF_LICENSE" => "any-value" } }
+      it "returns the value" do
+        expect(acc.value).to eq("any-value")
+      end
+    end
+
+    describe "when the environment contains the correct key but nil value" do
+      let(:env) { { "CHEF_LICENSE" => nil } }
+      it "returns nil" do
+        expect(acc.value).to eq(nil)
+      end
+    end
+
+    describe "when the environment does not contain the correct key" do
+      let(:env) { { "CHEF_LICENSE_ACCEPTANCE" => "any-value" } }
+      it "returns nil" do
+        expect(acc.value).to eq(nil)
+      end
+    end
+  end
 end

--- a/components/ruby/spec/license_acceptance/strategy/provided_value_spec.rb
+++ b/components/ruby/spec/license_acceptance/strategy/provided_value_spec.rb
@@ -52,4 +52,19 @@ RSpec.describe LicenseAcceptance::Strategy::ProvidedValue do
     end
   end
 
+  describe "#value?" do
+    describe "when the value is present" do
+      let(:value) { "any-value" }
+      it "returns true" do
+        expect(acc.value?).to eq(true)
+      end
+    end
+
+    describe "when the value is nil" do
+      let(:value) { nil }
+      it "returns false" do
+        expect(acc.value?).to eq(false)
+      end
+    end
+  end
 end

--- a/components/ruby/spec/spec_helper.rb
+++ b/components/ruby/spec/spec_helper.rb
@@ -1,5 +1,5 @@
 require "bundler/setup"
-require "license_acceptance/logger"
+require "license_acceptance/acceptor"
 require "logger"
 
 RSpec.configure do |config|


### PR DESCRIPTION
Signed-off-by: Pete Higgins <pete@peterhiggins.org>

## Description
When a user attempts to satisfy the license acceptance requirements with an unrecognized value, print an error message and quit instead of prompting them for acceptance with no indication of what went wrong.

This PR adds an example CLI app using the license-acceptance library for easier testing in development, without having to muck with the dependencies of infra client, inspec, etc.

The happy path of using a good value for license acceptance works:

```
Petes-MBP:ruby pete$ ./example/example_mixlib_cli_app.rb --chef-license=accept-no-persist
BIG SUCCESS
```

If the user uses an unrecognized value for license acceptance they get an error message and the app exits:

```
Petes-MBP:ruby pete$ ./example/example_mixlib_cli_app.rb --chef-license=accept-no-persistt
Unrecognized license acceptance value 'accept-no-persistt', expected one of: 'accept', 'accept-silent', 'accept-no-persist'
Chef Infra Client cannot execute without accepting the license
```

If the user does not do anything for license acceptance they are prompted for it:

```
Petes-MBP:ruby pete$ ./example/example_mixlib_cli_app.rb
+---------------------------------------------+
            Chef License Acceptance

Before you can continue, 1 product license
must be accepted. View the license at
https://www.chef.io/end-user-license-agreement/

License that need accepting:
  * Chef Infra Client

Do you accept the 1 product license (yes/no)?

> yes

Persisting 1 product license...
✔ 1 product license persisted.

+---------------------------------------------+
BIG SUCCESS
```

## Related Issue
An implementation of #84. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
