### PR TITLE
Remove yard tasks / unpin parallel gem

### DIFF
--- a/components/ruby/Gemfile
+++ b/components/ruby/Gemfile
@@ -6,19 +6,12 @@ git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 gemspec
 
 group :development do
-  gem "parallel", "< 1.20" # remove this pin/dep when we drop ruby < 2.4
   gem "chefstyle", "1.5.7"
   gem "climate_control", "~> 0.2"
   gem "mixlib-cli", "~> 2.1"
   gem "rake", ">= 10.1.0"
   gem "rspec", "~> 3.0"
   gem "thor", ">= 0.20", "< 2.0" # validate 2.0 when it ships
-end
-
-group :docs do
-  gem "yard"
-  gem "redcarpet"
-  gem "github-markup"
 end
 
 group :debug do

--- a/components/ruby/Rakefile
+++ b/components/ruby/Rakefile
@@ -14,10 +14,4 @@ rescue LoadError
   puts "chefstyle gem is not installed. bundle install first to make sure all dependencies are installed."
 end
 
-begin
-  require "yard"
-  YARD::Rake::YardocTask.new(:docs)
-rescue LoadError
-  puts "yard is not available. bundle install first to make sure all dependencies are installed."
-end
 task default: :spec


### PR DESCRIPTION
The parallel gem added back Ruby 2.4 support so we can nuke this pin now

Signed-off-by: Tim Smith <tsmith@chef.io>